### PR TITLE
Make dotdrop.sh pass all of the ShellCheck lints

### DIFF
--- a/dotdrop.sh
+++ b/dotdrop.sh
@@ -1,29 +1,31 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # author: deadc0de6 (https://github.com/deadc0de6)
 # Copyright (c) 2017, deadc0de6
 
 # check for readlink/realpath presence
 # https://github.com/deadc0de6/dotdrop/issues/6
 rl="readlink -f"
-${rl} >/dev/null 2>&1
-if [ "$?" != "0" ]; then
+
+if ! ${rl} >/dev/null 2>&1; then
   rl="realpath"
-  hash ${rl}
-  [ "$?" != "0" ] && echo "\"${rl}\" not found !" && exit 1
+
+  if ! hash ${rl}; then
+    echo "\"${rl}\" not found !" && exit 1
+  fi
 fi
 
 # setup variables
-args="$@"
-cur=`dirname $(${rl} ${0})`
-opwd=`pwd`
-bin="${cur}/dotdrop/dotdrop.py"
+args=$*
+cur=$(dirname "$(${rl} "${0}")")
+opwd=$(pwd)
+bin="${cur}/dotdrop/dotdrop/dotdrop.py"
 cfg="${cur}/config.yaml"
 
 # pivot
-cd ${cur}
+cd "${cur}" || exit
 # init the submodule
 git submodule update --init --recursive
 # launch dotdrop
-python3 ${bin} --cfg=${cfg} $args
+python3 "${bin}" --cfg="${cfg}" "${args}"
 # pivot back
-cd ${opwd}
+cd "${opwd}" || exit


### PR DESCRIPTION
I noticed that dotdrop.sh tripped quite a few ShellCheck lints, so I've made a patch to resolve all of the issues raised.

The issues ShellCheck found pre-patch can be seen below:

```
In dotdrop.sh line 9:
if [ "$?" != "0" ]; then
     ^-- SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In dotdrop.sh line 12:
  [ "$?" != "0" ] && echo "\"${rl}\" not found !" && exit 1
    ^-- SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In dotdrop.sh line 16:
args="$@"
     ^-- SC2124: Assigning an array to a string! Assign as array, or use * instead of @ to concatenate.


In dotdrop.sh line 17:
cur=`dirname $(${rl} ${0})`
    ^-- SC2006: Use $(..) instead of legacy `..`.
             ^-- SC2046: Quote this to prevent word splitting.
                     ^-- SC2086: Double quote to prevent globbing and word splitting.


In dotdrop.sh line 18:
opwd=`pwd`
     ^-- SC2006: Use $(..) instead of legacy `..`.


In dotdrop.sh line 23:
cd ${cur}
^-- SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
   ^-- SC2086: Double quote to prevent globbing and word splitting.


In dotdrop.sh line 27:
python3 ${bin} --cfg=${cfg} $args
        ^-- SC2086: Double quote to prevent globbing and word splitting.
                     ^-- SC2086: Double quote to prevent globbing and word splitting.
                            ^-- SC2086: Double quote to prevent globbing and word splitting.


In dotdrop.sh line 29:
cd ${opwd}
^-- SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
   ^-- SC2086: Double quote to prevent globbing and word splitting.
```