### PR TITLE
[FIX] Changed execution order of dotfiles

### DIFF
--- a/dotdrop/config.py
+++ b/dotdrop/config.py
@@ -241,8 +241,7 @@ class Cfg:
         if profile not in self.prodots:
             return []
         return sorted(self.prodots[profile],
-                      key=lambda x: str(x.key),
-                      reverse=True)
+                      key=lambda x: str(x.key))
 
     def get_profiles(self):
         """ returns all defined profiles """


### PR DESCRIPTION
Dotfiles now get executed ascending (key), e.g. 00 to 99 or aa to zz

Fixes bug #24 