### PR TITLE
Fix path calculation

### DIFF
--- a/dotdrop/templategen.py
+++ b/dotdrop/templategen.py
@@ -47,7 +47,7 @@ class Templategen:
         return self._handle_text_file(src, profile)
 
     def _handle_text_file(self, src, profile):
-        template_rel_path = relative_path_from_base(self.base, src)
+        template_rel_path = utils.relative_path_from_base(self.base, src)
         try:
             template = self.env.get_template(template_rel_path)
             content = template.render(profile=profile, env=os.environ)

--- a/dotdrop/templategen.py
+++ b/dotdrop/templategen.py
@@ -47,7 +47,7 @@ class Templategen:
         return self._handle_text_file(src, profile)
 
     def _handle_text_file(self, src, profile):
-        template_rel_path = src.split(self.base)[-1].lstrip(os.sep)
+        template_rel_path = relative_path_from_base(self.base, src)
         try:
             template = self.env.get_template(template_rel_path)
             content = template.render(profile=profile, env=os.environ)

--- a/dotdrop/utils.py
+++ b/dotdrop/utils.py
@@ -55,10 +55,10 @@ def remove(path):
     else:
         raise OSError("Unsupported file type for deletion: %s" % path)
 
-        
+
 def relative_path_from_base(base, path):
     ''' Return `path' relative to `base'.
-    
+
     >>> relative_path_from_base('base/dir', 'base/dir/some/file')
     'some/file'
     '''

--- a/dotdrop/utils.py
+++ b/dotdrop/utils.py
@@ -7,6 +7,7 @@ utilities
 import subprocess
 import tempfile
 import os
+import os.path
 import shlex
 from shutil import rmtree
 

--- a/dotdrop/utils.py
+++ b/dotdrop/utils.py
@@ -53,3 +53,18 @@ def remove(path):
         rmtree(path)
     else:
         raise OSError("Unsupported file type for deletion: %s" % path)
+
+        
+def relative_path_from_base(base, path):
+    ''' Return `path' relative to `base'.
+    
+    >>> relative_path_from_base('base/dir', 'base/dir/some/file')
+    'some/file'
+    '''
+    head, tail = path, ''
+    while head != base:
+        head, new_tail = os.path.split(head)
+        tail = os.path.join(new_tail, tail) if tail else new_tail
+        if not head:
+            raise ValueError('Path "%s" not under "%s"' % (path, base))
+    return tail


### PR DESCRIPTION
It seems that the simple path calculation in `Templategen._handle_text_file` breaks in specific circumstances.

My `.emacs.d` is a submodule in git, so `emacs.d/.git` is a text file. When it's fed into `Templategen._handle_text_file`, the path calculation on [line 50][old code] strips the leading dot from the name because my `dotpath` is set to `.`. This makes (e.g.) `dotdrop compare` crash with an error from Jinja:

```
$ dotdrop compare
Traceback (most recent call last):
  [snip]
jinja2.exceptions.TemplateNotFound: git
```

In the attached PR, I've changed that line to use a function using the `os.path` module, so that it works on path components as expected. It seems to solve the problem for me.

[old code]: https://github.com/deadc0de6/dotdrop/blob/8add24288248e483cbe4e90735030421f81e05e1/dotdrop/templategen.py#L50