### PR TITLE
handle subdirectories

### DIFF
--- a/dotdrop/dotdrop.py
+++ b/dotdrop/dotdrop.py
@@ -218,6 +218,10 @@ def update(opts, conf, path):
     return True
 
 
+def _lower_and_undot(name):
+    return name.lstrip('.').lower()
+
+
 def importer(opts, conf, paths):
     home = os.path.expanduser(TILD)
     cnt = 0
@@ -226,10 +230,13 @@ def importer(opts, conf, paths):
             LOG.err('\"{}\" does not exist, ignored !'.format(path))
             continue
         dst = path.rstrip(os.sep)
-        key = dst.split(os.sep)[-1]
-        if key == 'config':
-            key = '_'.join(dst.split(os.sep)[-2:])
-        key = key.lstrip('.').lower()
+        token = dst
+        if token.startswith(home):
+            temp = token.replace(home, '', 1)
+            if token != temp:
+                token = temp.lstrip('/')
+        tokens = list(map(_lower_and_undot, token.split(os.sep)))
+        key = '_'.join(tokens)
         if os.path.isdir(dst):
             key = 'd_{}'.format(key)
         else:


### PR DESCRIPTION
Hi,

It's me again...

I just hit a bug due to the way keys are generated.
The error is triggered when filenames within different folders are named the same.

Example:
```
dotdrop.sh import ~/.mutt/colors
dotdrop.sh import ~/.vim/colors
```

They both end up with the key `d_colors`

This PR changes the way keys are computed, resulting in respectively `d_mutt_colors` and `d_vim_colors`.
Note though this is kind of a **breaking** change

P.S.: I did not really understand the `if key == 'config'` thing, but I believe this is addressed as well with this new *tokenization* method.