### PR TITLE
Print OS error message when link failed

### DIFF
--- a/dotdrop/installer.py
+++ b/dotdrop/installer.py
@@ -95,8 +95,8 @@ class Installer:
                 return []
             try:
                 utils.remove(dst)
-            except OSError:
-                self.log.err('something went wrong with {}'.format(src))
+            except OSError as e:
+                self.log.err('something went wrong with {}: {}'.format(src, e))
                 return []
         if self.dry:
             self.log.dry('would link {} to {}'.format(dst, src))


### PR DESCRIPTION
Be more verbose by printing OSError exception message.

I'm debugging why dotdrop won't link my templates in root folders e.g. `/etc/hosts`
At the moment it only says "something went wrong" which is not as helpful as it could be.

With my change it would point to a permission problem.