### PR TITLE
Implement interpolation of current profile in config.yaml src paths

### DIFF
--- a/dotdrop/dotdrop.py
+++ b/dotdrop/dotdrop.py
@@ -94,7 +94,8 @@ def cmd_install(opts, conf, temporary=False, keys=[]):
     tmpdir = None
     if temporary:
         tmpdir = get_tmpdir()
-    inst = Installer(create=opts['create'], backup=opts['backup'],
+    inst = Installer(profile=opts['profile'],
+                     create=opts['create'], backup=opts['backup'],
                      dry=opts['dry'], safe=opts['safe'],
                      base=opts['dotpath'], workdir=opts['workdir'],
                      diff=opts['installdiff'], debug=opts['debug'],
@@ -158,7 +159,8 @@ def cmd_compare(opts, conf, tmp, focus=[], ignore=[]):
 
     t = Templategen(opts['profile'], base=opts['dotpath'],
                     variables=opts['variables'], debug=opts['debug'])
-    inst = Installer(create=opts['create'], backup=opts['backup'],
+    inst = Installer(profile=opts['profile'],
+                     create=opts['create'], backup=opts['backup'],
                      dry=opts['dry'], base=opts['dotpath'],
                      workdir=opts['workdir'], debug=opts['debug'])
     comp = Comparator(diffopts=opts['dopts'], debug=opts['debug'])

--- a/dotdrop/installer.py
+++ b/dotdrop/installer.py
@@ -6,6 +6,7 @@ handle the installation of dotfiles
 """
 
 import os
+import re
 
 # local imports
 from dotdrop.logger import Logger
@@ -17,10 +18,12 @@ import dotdrop.utils as utils
 class Installer:
 
     BACKUP_SUFFIX = '.dotdropbak'
+    PROFILE_INTERPOLATION = '{{dd_profile}}'
 
-    def __init__(self, base='.', create=True, backup=True,
+    def __init__(self, profile=None, base='.', create=True, backup=True,
                  dry=False, safe=False, workdir='~/.config/dotdrop',
                  debug=False, diff=True, totemp=None, showdiff=False):
+        self.profile = profile
         self.create = create
         self.backup = backup
         self.dry = dry
@@ -39,6 +42,7 @@ class Installer:
         """install the src to dst using a template"""
         self.action_executed = False
         src = os.path.join(self.base, os.path.expanduser(src))
+        src = src.replace(self.PROFILE_INTERPOLATION, self.profile or "")
         if not os.path.exists(src):
             self.log.err('source dotfile does not exist: {}'.format(src))
             return []
@@ -59,6 +63,7 @@ class Installer:
         """set src as the link target of dst"""
         self.action_executed = False
         src = os.path.join(self.base, os.path.expanduser(src))
+        src = src.replace(self.PROFILE_INTERPOLATION, self.profile or "")
         if not os.path.exists(src):
             self.log.err('source dotfile does not exist: {}'.format(src))
             return []


### PR DESCRIPTION
This is a sort of PoC PR for something I'm curious if you'd consider adding.

I noticed on another issue that you suggest using the templating feature to control all per-profile differences. While the templating feature is super powerful (it's one of the primary reasons I chose dotdrop!), sometimes it's more useful to just have separate files/directories for different hosts, namely when there are deeply nested differences between the two.

This implements functionality so that you can use a special interpolation, `{{dd_profile}}` in any `src:` entries in config.yaml. It will get replaced with the name of the current profile being installed/compared.

This way you can have something like:
`<dotfiles>/fish/arch_w/`
That you can have installed on `arch_w` by doing
```
d_fish:
  - dst: ~/.config/fish/
  - src: fish/{{dd_profile}}
```

Let me know what you think, and thanks for the awesome tool!