### PR TITLE
Fix bug with linking to broken symlink

### DIFF
--- a/dotdrop/installer.py
+++ b/dotdrop/installer.py
@@ -64,7 +64,7 @@ class Installer:
         if not os.path.exists(src):
             self.log.err('source dotfile does not exist: {}'.format(src))
             return []
-        dst = os.path.expanduser(dst)
+        dst = os.path.expanduser(dst).rstrip('/')
         if self.totemp:
             # ignore actions
             return self.install(templater, src, dst, actions=[])


### PR DESCRIPTION
This adjustment fixes the exception thrown when `link()` is called with the destination being a broken symlink and having a trailing `/`. `os.path.lexists(dst)` (called [here](https://github.com/deadc0de6/dotdrop/blob/0dd9dea1ffa76155c95dbad8f741764fb04a1316/dotdrop/installer.py#L85)) only returns true for broken symlinks without the trailing `/`.