### PR TITLE
Feature link_children

### DIFF
--- a/dotdrop/dotdrop.py
+++ b/dotdrop/dotdrop.py
@@ -19,7 +19,7 @@ from dotdrop.updater import Updater
 from dotdrop.comparator import Comparator
 from dotdrop.dotfile import Dotfile
 from dotdrop.config import Cfg
-import dotdrop.utils as dd
+from dotdrop.utils import get_tmpdir, remove, strip_home, run
 from dotdrop.linktypes import LinkTypes
 
 LOG = Logger()
@@ -92,7 +92,7 @@ def cmd_install(opts, conf, temporary=False, keys=[]):
                     variables=opts['variables'], debug=opts['debug'])
     tmpdir = None
     if temporary:
-        tmpdir = dd.get_tmpdir()
+        tmpdir = get_tmpdir()
     inst = Installer(create=opts['create'], backup=opts['backup'],
                      dry=opts['dry'], safe=opts['safe'],
                      base=opts['dotpath'], workdir=opts['workdir'],
@@ -123,7 +123,7 @@ def cmd_install(opts, conf, temporary=False, keys=[]):
             if tmp:
                 tmp = os.path.join(opts['dotpath'], tmp)
                 if os.path.exists(tmp):
-                    dd.remove(tmp)
+                    remove(tmp)
         if len(r) > 0:
             if Cfg.key_actions_post in dotfile.actions:
                 actions = dotfile.actions[Cfg.key_actions_post]
@@ -191,7 +191,7 @@ def cmd_compare(opts, conf, tmp, focus=[], ignore=[]):
             # clean tmp transformed dotfile if any
             tmpsrc = os.path.join(opts['dotpath'], tmpsrc)
             if os.path.exists(tmpsrc):
-                dd.remove(tmpsrc)
+                remove(tmpsrc)
         if diff == '':
             if opts['debug']:
                 LOG.dbg('diffing \"{}\" VS \"{}\"'.format(dotfile.key,
@@ -245,7 +245,7 @@ def cmd_importer(opts, conf, paths):
             continue
         dst = path.rstrip(os.sep)
         dst = os.path.abspath(dst)
-        src = dd.strip_home(dst)
+        src = strip_home(dst)
         strip = '.' + os.sep
         if opts['keepdot']:
             strip = os.sep
@@ -264,7 +264,7 @@ def cmd_importer(opts, conf, paths):
             if opts['dry']:
                 LOG.dry('would run: {}'.format(' '.join(cmd)))
             else:
-                r, _ = dd.run(cmd, raw=False, debug=opts['debug'], checkerr=True)
+                r, _ = run(cmd, raw=False, debug=opts['debug'], checkerr=True)
                 if not r:
                     LOG.err('importing \"{}\" failed!'.format(path))
                     ret = False
@@ -275,13 +275,13 @@ def cmd_importer(opts, conf, paths):
                 if linkit:
                     LOG.dry('would symlink {} to {}'.format(srcf, dst))
             else:
-                r, _ = dd.run(cmd, raw=False, debug=opts['debug'], checkerr=True)
+                r, _ = run(cmd, raw=False, debug=opts['debug'], checkerr=True)
                 if not r:
                     LOG.err('importing \"{}\" failed!'.format(path))
                     ret = False
                     continue
                 if linkit:
-                    dd.remove(dst)
+                    remove(dst)
                     os.symlink(srcf, dst)
         retconf, dotfile = conf.new(dotfile, opts['profile'],
                                     link=linkit, debug=opts['debug'])
@@ -402,7 +402,7 @@ def apply_trans(opts, dotfile):
         msg = 'transformation \"{}\" failed for {}'
         LOG.err(msg.format(trans.key, dotfile.key))
         if new_src and os.path.exists(new_src):
-            dd.remove(new_src)
+            remove(new_src)
         return None
     return new_src
 
@@ -471,12 +471,12 @@ def main():
             # compare local dotfiles with dotfiles stored in dotdrop
             if opts['debug']:
                 LOG.dbg('running cmd: compare')
-            tmp = dd.get_tmpdir()
+            tmp = get_tmpdir()
             opts['dopts'] = args['--dopts']
             ret = cmd_compare(opts, conf, tmp, focus=args['--file'],
                               ignore=args['--ignore'])
             # clean tmp directory
-            dd.remove(tmp)
+            remove(tmp)
 
         elif args['import']:
             # import dotfile(s)

--- a/dotdrop/dotfile.py
+++ b/dotdrop/dotfile.py
@@ -5,12 +5,14 @@ Copyright (c) 2017, deadc0de6
 represents a dotfile in dotdrop
 """
 
+from dotdrop.linktypes import LinkTypes
+
 
 class Dotfile:
 
     def __init__(self, key, dst, src,
                  actions={}, trans_r=None, trans_w=None,
-                 link=False, cmpignore=[], noempty=False):
+                 link=LinkTypes.NOLINK, cmpignore=[], noempty=False):
         # key of dotfile in the config
         self.key = key
         # path where to install this dotfile
@@ -32,10 +34,11 @@ class Dotfile:
 
     def __str__(self):
         msg = 'key:\"{}\", src:\"{}\", dst:\"{}\", link:\"{}\"'
-        return msg.format(self.key, self.src, self.dst, self.link)
+        return msg.format(self.key, self.src, self.dst, self.link.name)
 
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
 
     def __hash__(self):
         return hash(self.dst) ^ hash(self.src) ^ hash(self.key)
+

--- a/dotdrop/linktypes.py
+++ b/dotdrop/linktypes.py
@@ -1,0 +1,8 @@
+from enum import IntEnum
+
+
+class LinkTypes(IntEnum):
+    NOLINK = 0
+    PARENTS = 1
+    CHILDREN = 2
+

--- a/dotdrop/utils.py
+++ b/dotdrop/utils.py
@@ -10,11 +10,12 @@ import tempfile
 import os
 import uuid
 import shlex
+import functools
+import operator
 from shutil import rmtree
 
 # local import
 from dotdrop.logger import Logger
-from dotdrop.version import __version__ as VERSION
 
 LOG = Logger()
 
@@ -109,3 +110,9 @@ def strip_home(path):
     if path.startswith(home):
         path = path[len(home):]
     return path
+
+
+def flatten(a):
+    """flatten list"""
+    return functools.reduce(operator.iconcat, a, [])
+


### PR DESCRIPTION
This feature would allow you to symlink only child directories of a dotfile to a given destination. I have found this very useful for dotfiles such as vim. This feature allows me to have a structure like this inside `~/.vim/`:

```
after -> ~/.dotfiles/vim/after
autoload
plugged
plugin -> ~/.dotfiles/vim/plugin
snippets -> ~/.dotfiles/vim/snippets
spell
swap
vimrc -> ~/.dotfiles/vim/vimrc
```
As you can see, I can store my `vimrc`, snippets, and custom plugins in my source-controlled `~/.dotfiles` directory, I can have all these files symlinked (so I stop scratching my head why my edits aren't working when I forget to `dotdrop install`), and my Plug plugins and swap files don't make their way into my repository. The setting for this is:
```yml
  vim:
    dst: ~/.vim/
    src: ./vim/
    actions:
     - vim-plug-install
     - vim-plug
    link_children: true
```

This is kind of a big change and I understand if you don't want to merge. If you think this is something you might want to merge, I can work on docs and tests.