### PR TITLE
Normalize paths when linking

### DIFF
--- a/dotdrop/installer.py
+++ b/dotdrop/installer.py
@@ -60,7 +60,8 @@ class Installer:
     def link(self, templater, src, dst, actions=[]):
         """set src as the link target of dst"""
         self.action_executed = False
-        src = os.path.join(self.base, os.path.expanduser(src))
+        src = os.path.normpath(os.path.join(self.base,
+                                            os.path.expanduser(src)))
         if not os.path.exists(src):
             self.log.err('source dotfile does not exist: {}'.format(src))
             return []
@@ -118,8 +119,10 @@ class Installer:
             os.mkdir(dst)
 
         children = os.listdir(parent)
-        srcs = [os.path.join(parent, child) for child in children]
-        dsts = [os.path.join(dst, child) for child in children]
+        srcs = [os.path.normpath(os.path.join(parent, child))
+                for child in children]
+        dsts = [os.path.normpath(os.path.join(dst, child))
+                for child in children]
 
         for i in range(len(children)):
             src = srcs[i]


### PR DESCRIPTION
This is a small change. I simply call `os.path.normalize` to strip necessary parts of the path when linking. It just cleans up the links a bit. For example, for me, it changes `~/./.dotfiles` to `~/.dotfiles`. It's minor, but it bothered me.