### PR TITLE
Expand variables in jinja helper path

### DIFF
--- a/dotdrop/jhelpers.py
+++ b/dotdrop/jhelpers.py
@@ -10,4 +10,4 @@ import os
 
 def exists(path):
     """return true when path exists"""
-    return os.path.exists(path)
+    return os.path.exists(os.path.expandvars(path))


### PR DESCRIPTION
This changes the `exists` jinja helper function to expand environment variables before checking the path.

My specific use case for this is checking whether [`rvm`](http://rvm.io/) or [`nvm`](https://github.com/creationix/nvm) have been installed in `$HOME` before sourcing them.