### PR TITLE
Add jinja helper to test executable in PATH

### DIFF
--- a/dotdrop/jhelpers.py
+++ b/dotdrop/jhelpers.py
@@ -6,8 +6,14 @@ jinja2 helper methods
 """
 
 import os
+import shutil
 
 
 def exists(path):
     """return true when path exists"""
     return os.path.exists(os.path.expandvars(path))
+
+
+def exists_in_path(name, path=None):
+    """return true when executable exists in os path"""
+    return shutil.which(name, os.F_OK | os.X_OK, path) is not None

--- a/dotdrop/templategen.py
+++ b/dotdrop/templategen.py
@@ -49,6 +49,7 @@ class Templategen:
         self.env.globals['header'] = self._header
         # adding helper methods
         self.env.globals['exists'] = jhelpers.exists
+        self.env.globals['exists_in_path'] = jhelpers.exists_in_path
 
     def generate(self, src):
         """render template from path"""

--- a/tests-ng/jhelpers.sh
+++ b/tests-ng/jhelpers.sh
@@ -83,6 +83,19 @@ echo "{%@@ if exists('/dev/abcdef') @@%}" >> ${tmps}/dotfiles/abc
 echo "this should not exist" >> ${tmps}/dotfiles/abc
 echo "{%@@ endif @@%}" >> ${tmps}/dotfiles/abc
 
+# test exists_in_path
+cat >> ${tmps}/dotfiles/abc << _EOF
+{%@@ if exists_in_path('cat') @@%}
+this should exist too
+{%@@ endif @@%}
+_EOF
+
+cat >> ${tmps}/dotfiles/abc << _EOF
+{%@@ if exists_in_path('a_name_that_is_unlikely_to_be_chosen_for_an_executable') @@%}
+this should not exist either
+{%@@ endif @@%}
+_EOF
+
 #cat ${tmps}/dotfiles/abc
 
 # install
@@ -92,6 +105,8 @@ cd ${ddpath} | ${bin} install -f -c ${cfg} -p p1 -V
 
 grep '^this should exist' ${tmpd}/abc >/dev/null
 grep -v '^this should not exist' ${tmpd}/abc >/dev/null
+grep '^this should exist too' ${tmpd}/abc >/dev/null
+grep -v '^this should not exist either' ${tmpd}/abc >/dev/null
 
 #cat ${tmpd}/abc
 


### PR DESCRIPTION
This adds a new Jinja helper function that allows checking whether an executable exists in the OS's `PATH` within templates.

Example:

```sh
## ls variations
{%@@ if exists_in_path('exa') @@%}
alias ls='exa --git --color=always'
alias tree='ls -T'
alias ll="ls -l --group-directories-first"
alias la='ls -a'
alias lla='ll -a'
{%@@ else @@%}
alias ls='ls -h --color=always'
alias tree='tree -Csuh'
alias ll="ls -lv --group-directories-first"
alias la='ls -A'
alias lla='ls -lA'
{%@@ endif @@%}
```