### PR TITLE
Import config

### DIFF
--- a/dotdrop/action.py
+++ b/dotdrop/action.py
@@ -14,6 +14,7 @@ from dotdrop.logger import Logger
 
 
 class Cmd:
+    eq_ignore = ('log',)
 
     def __init__(self, key, action):
         """constructor
@@ -31,7 +32,17 @@ class Cmd:
         return 'cmd({})'.format(self.__str__())
 
     def __eq__(self, other):
-        return self.__dict__ == other.__dict__
+        self_dict = {
+            k: v
+            for k, v in self.__dict__.items()
+            if k not in self.eq_ignore
+        }
+        other_dict = {
+            k: v
+            for k, v in other.__dict__.items()
+            if k not in self.eq_ignore
+        }
+        return self_dict == other_dict
 
     def __hash__(self):
         return hash(self.key) ^ hash(self.action)

--- a/dotdrop/config.py
+++ b/dotdrop/config.py
@@ -337,8 +337,12 @@ class Cfg:
 
         dotfiles = self.content[self.key_dotfiles]
         noempty_default = self.lnk_settings[self.key_ignoreempty]
+        dotpath = self.content['config']['dotpath']
         for k, v in dotfiles.items():
-            src = os.path.normpath(v[self.key_dotfiles_src])
+            src = v[self.key_dotfiles_src]
+            if dotpath not in src:
+                src = os.path.join(dotpath, src)
+            src = os.path.normpath(self._abs_path(src))
             dst = os.path.normpath(v[self.key_dotfiles_dst])
 
             # Fail if both `link` and `link_children` present

--- a/dotdrop/config.py
+++ b/dotdrop/config.py
@@ -480,8 +480,12 @@ class Cfg:
             self_member = getattr(self, member_name)
             ext_member = getattr(ext_config, member_name)
 
-        common_keys = (set(self_member.keys())
-                       .intersection(set(ext_member.keys())))
+        common_keys = (
+            key
+            for key in (set(self_member.keys())
+                        .intersection(set(ext_member.keys())))
+            if not key.startswith('_')
+        )
         warning_msg = ('%s {} defined both in %s and %s: {} in %s used'
                        % (warning_prefix, self.cfgpath, ext_config.cfgpath,
                           self.cfgpath))

--- a/dotdrop/config.py
+++ b/dotdrop/config.py
@@ -147,6 +147,9 @@ class Cfg:
         if not self._load_config(profile=profile):
             raise ValueError('config is not valid')
 
+    def __eq__(self, other):
+        return self.cfgpath == other.cfgpath
+
     def eval_dotfiles(self, profile, variables, debug=False):
         """resolve dotfiles src/dst/actions templating for this profile"""
         t = Templategen(variables=variables)
@@ -282,7 +285,11 @@ class Cfg:
         # If read transformations are None, replaces them with empty dict
         try:
             read_trans = self.content[self.key_trans_r] or {}
-            self.trans_r = {k: Transform(k, v) for k, v in read_trans.items()}
+            self.trans_r.update({
+                k: Transform(k, v)
+                for k, v
+                in read_trans.items()
+            })
         except KeyError:
             pass
 
@@ -290,7 +297,11 @@ class Cfg:
         # If write transformations are None, replaces them with empty dict
         try:
             read_trans = self.content[self.key_trans_w] or {}
-            self.trans_w = {k: Transform(k, v) for k, v in read_trans.items()}
+            self.trans_w.update({
+                k: Transform(k, v)
+                for k, v
+                in read_trans.items()
+            })
         except KeyError:
             pass
 
@@ -439,6 +450,14 @@ class Cfg:
         except ValueError:
             raise ValueError(
                 'external config file not found: {}'.format(config_path))
+
+        list_settings = (
+            (k, v)
+            for k, v in ext_config.lnk_settings.items()
+            if isinstance(v, list)
+        )
+        for k, v in list_settings:
+            self.lnk_settings[k] += v
 
         ext_members = (
             (name, member)

--- a/dotdrop/config.py
+++ b/dotdrop/config.py
@@ -445,12 +445,14 @@ class Cfg:
         return True
 
     def _merge_cfg(self, config_path):
+        # Parsing external config file
         try:
             ext_config = Cfg(self._abs_path(config_path))
         except ValueError:
             raise ValueError(
                 'external config file not found: {}'.format(config_path))
 
+        # Merging lists in config settings
         list_settings = (
             (k, v)
             for k, v in ext_config.lnk_settings.items()
@@ -459,6 +461,7 @@ class Cfg:
         for k, v in list_settings:
             self.lnk_settings[k] += v
 
+        # Merging dictionaries
         ext_members = (
             (name, member)
             for name, member in inspect.getmembers(ext_config, is_dict)
@@ -468,6 +471,16 @@ class Cfg:
             self_member = getattr(self, name, {})
             ext_member.update(self_member)
             setattr(self, name, ext_member)
+
+        # Merging variables
+        self_content, ext_content = self.content, ext_config.content
+        (ext_content[self.key_variables]
+            .update(self_content[self.key_variables]))
+        self.content[self.key_variables] = ext_content[self.key_variables]
+        (ext_content[self.key_dynvariables]
+            .update(self_content[self.key_dynvariables]))
+        self.content[self.key_dynvariables] = \
+            ext_content[self.key_dynvariables]
 
     def _load_ext_variables(self, paths, profile=None):
         """load external variables"""

--- a/dotdrop/config.py
+++ b/dotdrop/config.py
@@ -5,16 +5,18 @@ Copyright (c) 2017, deadc0de6
 yaml config file manager
 """
 
-import yaml
+import inspect
 import os
 import shlex
+
+import yaml
 
 # local import
 from dotdrop.dotfile import Dotfile
 from dotdrop.templategen import Templategen
 from dotdrop.logger import Logger
 from dotdrop.action import Action, Transform
-from dotdrop.utils import strip_home, shell
+from dotdrop.utils import is_dict, is_not_magic, strip_home, shell
 from dotdrop.linktypes import LinkTypes
 
 
@@ -38,7 +40,7 @@ class Cfg:
     # import keys
     key_import_vars = 'import_variables'
     key_import_actions = 'import_actions'
-    key_import_profiles = 'import_profiles'
+    key_import_configs = 'import_configs'
 
     # actions keys
     key_actions = 'actions'
@@ -262,13 +264,9 @@ class Cfg:
 
         # parse external profiles
         try:
-            ext_configs = self.lnk_settings[self.key_import_profiles]
+            ext_configs = self.lnk_settings[self.key_import_configs] or ()
             for config in ext_configs:
-                ext_config = Cfg(config)
-                self.dotfiles.update(ext_config.dotfiles)
-                self.lnk_profiles.update(ext_config.lnk_profiles)
-                self.prodots.update(ext_config.prodots)
-                # need variables, actions and so on
+                self._merge_cfg(config)
         except KeyError:
             pass
 
@@ -434,6 +432,23 @@ class Cfg:
                 df = ','.join(d.key for d in self.prodots[k])
                 self.log.dbg('dotfiles for \"{}\": {}'.format(k, df))
         return True
+
+    def _merge_cfg(self, config_path):
+        try:
+            ext_config = Cfg(self._abs_path(config_path))
+        except ValueError:
+            raise ValueError(
+                'external config file not found: {}'.format(config_path))
+
+        ext_members = (
+            (name, member)
+            for name, member in inspect.getmembers(ext_config, is_dict)
+            if name != 'content' and is_not_magic(name)
+        )
+        for name, ext_member in ext_members:
+            self_member = getattr(self, name, {})
+            ext_member.update(self_member)
+            setattr(self, name, ext_member)
 
     def _load_ext_variables(self, paths, profile=None):
         """load external variables"""

--- a/dotdrop/config.py
+++ b/dotdrop/config.py
@@ -38,6 +38,7 @@ class Cfg:
     # import keys
     key_import_vars = 'import_variables'
     key_import_actions = 'import_actions'
+    key_import_profiles = 'import_profiles'
 
     # actions keys
     key_actions = 'actions'
@@ -256,6 +257,18 @@ class Cfg:
                     self._load_actions(external_actions)
                 except KeyError:
                     pass
+        except KeyError:
+            pass
+
+        # parse external profiles
+        try:
+            ext_configs = self.lnk_settings[self.key_import_profiles]
+            for config in ext_configs:
+                ext_config = Cfg(config)
+                self.dotfiles.update(ext_config.dotfiles)
+                self.lnk_profiles.update(ext_config.lnk_profiles)
+                self.prodots.update(ext_config.prodots)
+                # need variables, actions and so on
         except KeyError:
             pass
 
@@ -758,9 +771,12 @@ class Cfg:
     def _dotfile_exists(self, dotfile):
         """return True and the existing dotfile key
         if it already exists, False and a new unique key otherwise"""
-        dsts = [(k, d.dst) for k, d in self.dotfiles.items()]
-        if dotfile.dst in [x[1] for x in dsts]:
-            return True, [x[0] for x in dsts if x[1] == dotfile.dst][0]
+        try:
+            return True, next(key
+                              for key, d in self.dotfiles.items()
+                              if d.dst == dotfile.dst)
+        except StopIteration:
+            pass
         # return key for this new dotfile
         path = os.path.expanduser(dotfile.dst)
         keys = self.dotfiles.keys()

--- a/dotdrop/config.py
+++ b/dotdrop/config.py
@@ -34,6 +34,8 @@ class Cfg:
     key_imp_link = 'link_on_import'
     key_dotfile_link = 'link_dotfile_default'
     key_workdir = 'workdir'
+
+    # import keys
     key_import_vars = 'import_variables'
     key_import_actions = 'import_actions'
 
@@ -98,6 +100,7 @@ class Cfg:
             raise ValueError('config file path undefined')
         if not os.path.exists(cfgpath):
             raise ValueError('config file does not exist: {}'.format(cfgpath))
+
         # make sure to have an absolute path to config file
         self.cfgpath = os.path.abspath(cfgpath)
         self.debug = debug
@@ -213,29 +216,25 @@ class Cfg:
             return False
 
         # parse the profiles
-        self.lnk_profiles = self.content[self.key_profiles]
-        if self.lnk_profiles is None:
-            # ensures self.lnk_profiles is a dict
+        # ensures self.lnk_profiles is a dict
+        if not isinstance(self.content[self.key_profiles], dict):
             self.content[self.key_profiles] = {}
-            self.lnk_profiles = self.content[self.key_profiles]
-        for k, v in self.lnk_profiles.items():
-            if not v:
-                continue
-            if self.key_profiles_dots in v and \
-                    v[self.key_profiles_dots] is None:
-                # if has the dotfiles entry but is empty
-                # ensures it's an empty list
-                v[self.key_profiles_dots] = []
+
+        self.lnk_profiles = self.content[self.key_profiles]
+        for p in filter(bool, self.lnk_profiles.values()):
+            # Ensures that the dotfiles entry is an empty list when not given
+            # or none
+            p.setdefault(self.key_profiles_dots, [])
+            if p[self.key_profiles_dots] is None:
+                p[self.key_profiles_dots] = []
 
         # make sure we have an absolute dotpath
         self.curdotpath = self.lnk_settings[self.key_dotpath]
-        self.lnk_settings[self.key_dotpath] = \
-            self._abs_path(self.curdotpath)
+        self.lnk_settings[self.key_dotpath] = self._abs_path(self.curdotpath)
 
         # make sure we have an absolute workdir
         self.curworkdir = self.lnk_settings[self.key_workdir]
-        self.lnk_settings[self.key_workdir] = \
-            self._abs_path(self.curworkdir)
+        self.lnk_settings[self.key_workdir] = self._abs_path(self.curworkdir)
 
         # load external variables/dynvariables
         if self.key_import_vars in self.lnk_settings:
@@ -243,7 +242,7 @@ class Cfg:
             self._load_ext_variables(paths, profile=profile)
 
         # parse external actions
-        if self.key_import_actions in self.lnk_settings:
+        try:
             for path in self.lnk_settings[self.key_import_actions]:
                 path = self._abs_path(path)
                 if self.debug:
@@ -252,6 +251,8 @@ class Cfg:
                 if self.key_actions in content and \
                         content[self.key_actions] is not None:
                     self._load_actions(content[self.key_actions])
+        except KeyError:
+            pass
 
         # parse local actions
         if self.key_actions in self.content and \
@@ -270,14 +271,14 @@ class Cfg:
             for k, v in self.content[self.key_trans_w].items():
                 self.trans_w[k] = Transform(k, v)
 
-        # parse the dotfiles
-        # and construct the dict of objects per dotfile key
-        if not self.content[self.key_dotfiles]:
-            # ensures the dotfiles entry is a dict
+        # parse the dotfiles and construct the dict of objects per dotfile key
+        # ensures the dotfiles entry is a dict
+        if not isinstance(self.content[self.key_dotfiles], dict):
             self.content[self.key_dotfiles] = {}
 
-        for k in self.content[self.key_dotfiles].keys():
-            v = self.content[self.key_dotfiles][k]
+        dotfiles = self.content[self.key_dotfiles]
+        noempty_default = self.lnk_settings[self.key_ignoreempty]
+        for k, v in dotfiles.items():
             src = os.path.normpath(v[self.key_dotfiles_src])
             dst = os.path.normpath(v[self.key_dotfiles_dst])
 
@@ -291,7 +292,7 @@ class Cfg:
 
             # fix it
             v = self._fix_dotfile_link(k, v)
-            self.content[self.key_dotfiles][k] = v
+            dotfiles[k] = v
 
             # get link type
             link = self._get_def_link()
@@ -299,18 +300,14 @@ class Cfg:
                 link = self._string_to_linktype(v[self.key_dotfiles_link])
 
             # get ignore empty
-            noempty = v[self.key_dotfiles_noempty] if \
-                self.key_dotfiles_noempty \
-                in v else self.lnk_settings[self.key_ignoreempty]
+            noempty = v.get(self.key_dotfiles_noempty, noempty_default)
 
             # parse actions
-            itsactions = v[self.key_dotfiles_actions] if \
-                self.key_dotfiles_actions in v else []
+            itsactions = v.get(self.key_dotfiles_actions, [])
             actions = self._parse_actions(itsactions)
 
             # parse read transformation
-            itstrans_r = v[self.key_dotfiles_trans_r] if \
-                self.key_dotfiles_trans_r in v else None
+            itstrans_r = v.get(self.key_dotfiles_trans_r)
             trans_r = None
             if itstrans_r:
                 if type(itstrans_r) is list:
@@ -327,8 +324,7 @@ class Cfg:
                     return False
 
             # parse write transformation
-            itstrans_w = v[self.key_dotfiles_trans_w] if \
-                self.key_dotfiles_trans_w in v else None
+            itstrans_w = v.get(self.key_dotfiles_trans_w)
             trans_w = None
             if itstrans_w:
                 if type(itstrans_w) is list:
@@ -353,12 +349,10 @@ class Cfg:
                 trans_w = None
 
             # parse cmpignore pattern
-            cmpignores = v[self.key_dotfiles_cmpignore] if \
-                self.key_dotfiles_cmpignore in v else []
+            cmpignores = v.get(self.key_dotfiles_cmpignore, [])
 
             # parse upignore pattern
-            upignores = v[self.key_dotfiles_upignore] if \
-                self.key_dotfiles_upignore in v else []
+            upignores = v.get(self.key_dotfiles_upignore, [])
 
             # create new dotfile
             self.dotfiles[k] = Dotfile(k, dst, src,
@@ -368,16 +362,14 @@ class Cfg:
                                        upignore=upignores)
 
         # assign dotfiles to each profile
-        for k, v in self.lnk_profiles.items():
-            self.prodots[k] = []
-            if not v:
+        self.prodots = {k: [] for k in self.lnk_profiles.keys()}
+        for name, profile in self.lnk_profiles.items():
+            if not profile:
                 continue
-            if self.key_profiles_dots not in v:
-                # ensures is a list
-                v[self.key_profiles_dots] = []
-            if not v[self.key_profiles_dots]:
+            dots = profile[self.key_profiles_dots]
+            if not dots:
                 continue
-            dots = v[self.key_profiles_dots]
+
             if self.key_all in dots:
                 # add all if key ALL is used
                 self.prodots[k] = list(self.dotfiles.values())
@@ -388,10 +380,11 @@ class Cfg:
                         msg = 'unknown dotfile \"{}\" for {}'.format(d, k)
                         self.log.err(msg)
                         continue
-                    self.prodots[k].append(self.dotfiles[d])
+                    self.prodots[name].append(self.dotfiles[d])
 
+        profile_names = self.lnk_profiles.keys()
         # handle "import" (from file) for each profile
-        for k in self.lnk_profiles.keys():
+        for k in profile_names:
             dots = self._get_imported_dotfiles_keys(k)
             for d in dots:
                 if d not in self.dotfiles:
@@ -401,20 +394,19 @@ class Cfg:
                 self.prodots[k].append(self.dotfiles[d])
 
         # handle "include" (from other profile) for each profile
-        for k in self.lnk_profiles.keys():
+        for k in profile_names:
             ret, dots = self._get_included_dotfiles(k)
             if not ret:
                 return False
             self.prodots[k].extend(dots)
 
         # remove duplicates if any
-        for k in self.lnk_profiles.keys():
-            self.prodots[k] = list(set(self.prodots[k]))
+        self.prodots = {k: list(set(v)) for k, v in self.prodots.items()}
 
         # print dotfiles for each profile
         if self.debug:
             for k in self.lnk_profiles.keys():
-                df = ','.join([d.key for d in self.prodots[k]])
+                df = ','.join(d.key for d in self.prodots[k])
                 self.log.dbg('dotfiles for \"{}\": {}'.format(k, df))
         return True
 

--- a/dotdrop/config.py
+++ b/dotdrop/config.py
@@ -9,6 +9,7 @@ import inspect
 import itertools
 import os
 import shlex
+from functools import partial
 from glob import iglob
 
 import yaml
@@ -267,11 +268,29 @@ class Cfg:
         except KeyError:
             pass
 
-        # parse external profiles
+        # parse external configs
         try:
             ext_configs = self.lnk_settings[self.key_import_configs] or ()
+
+            try:
+                iglob('./*', recursive=True)
+                find_glob = partial(iglob, recursive=True)
+            except TypeError:
+                from platform import python_version
+
+                msg = ('Recursive globbing is not available on Python {}: '
+                       .format(python_version()))
+                if any('**' in config for config in ext_configs):
+                    msg += "import_configs won't work"
+                    self.log.err(msg)
+                    return False
+
+                msg = 'upgrade to version >3.5 if you want to use this feature'
+                self.log.warn(msg)
+                find_glob = iglob
+
             ext_configs = itertools.chain.from_iterable(
-                iglob(self._abs_path(config), recursive=True)
+                find_glob(self._abs_path(config))
                 for config in ext_configs
             )
             for config in ext_configs:

--- a/dotdrop/config.py
+++ b/dotdrop/config.py
@@ -6,8 +6,10 @@ yaml config file manager
 """
 
 import inspect
+import itertools
 import os
 import shlex
+from glob import iglob
 
 import yaml
 
@@ -268,6 +270,10 @@ class Cfg:
         # parse external profiles
         try:
             ext_configs = self.lnk_settings[self.key_import_configs] or ()
+            ext_configs = itertools.chain.from_iterable(
+                iglob(self._abs_path(config), recursive=True)
+                for config in ext_configs
+            )
             for config in ext_configs:
                 self._merge_cfg(config)
         except KeyError:
@@ -447,7 +453,7 @@ class Cfg:
     def _merge_cfg(self, config_path):
         # Parsing external config file
         try:
-            ext_config = Cfg(self._abs_path(config_path))
+            ext_config = Cfg(config_path)
         except ValueError:
             raise ValueError(
                 'external config file not found: {}'.format(config_path))

--- a/dotdrop/utils.py
+++ b/dotdrop/utils.py
@@ -133,8 +133,10 @@ def must_ignore(paths, ignores, debug=False):
 
 
 def is_dict(obj):
+    """Return true if obj is dict."""
     return isinstance(obj, dict)
 
 
 def is_not_magic(name):
+    """Return true if name is not a magic method name."""
     return (name[0:2], name[-2:]) != ('__', '__')

--- a/dotdrop/utils.py
+++ b/dotdrop/utils.py
@@ -130,13 +130,3 @@ def must_ignore(paths, ignores, debug=False):
                     LOG.dbg('ignore \"{}\" match: {}'.format(i, p))
                 return True
     return False
-
-
-def is_dict(obj):
-    """Return true if obj is dict."""
-    return isinstance(obj, dict)
-
-
-def is_not_magic(name):
-    """Return true if name is not a magic method name."""
-    return (name[0:2], name[-2:]) != ('__', '__')

--- a/dotdrop/utils.py
+++ b/dotdrop/utils.py
@@ -130,3 +130,11 @@ def must_ignore(paths, ignores, debug=False):
                     LOG.dbg('ignore \"{}\" match: {}'.format(i, p))
                 return True
     return False
+
+
+def is_dict(obj):
+    return isinstance(obj, dict)
+
+
+def is_not_magic(name):
+    return (name[0:2], name[-2:]) != ('__', '__')

--- a/tests.sh
+++ b/tests.sh
@@ -34,6 +34,8 @@ PYTHONPATH=dotdrop ${nosebin} -s --with-coverage --cover-package=dotdrop
 #PYTHONPATH=dotdrop python3 -m pytest tests
 
 ## execute bash script tests
-for scr in tests-ng/*.sh; do
-  ${scr}
-done
+[ "$1" = '--python-only' ] || {
+    for scr in tests-ng/*.sh; do
+        ${scr}
+    done
+}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -148,7 +148,6 @@ def load_options(confpath, profile):
     o = Options(args=args)
     o.profile = profile
     o.dry = False
-    o.profile = profile
     o.safe = True
     o.install_diff = True
     o.import_link = LinkTypes.NOLINK
@@ -221,9 +220,9 @@ def create_yaml_keyval(pairs, parent_dir=None, top_key=None):
     return file_name
 
 
-def populate_fake_config(config, dotfiles=(), profiles=(), actions=(),
-                         trans=(), trans_write=(), variables=(),
-                         dynvariables=()):
+def populate_fake_config(config, dotfiles={}, profiles={}, actions={},
+                         trans={}, trans_write={}, variables={},
+                         dynvariables={}):
     """Adds some juicy content to config files"""
     is_path = isinstance(config, str)
     if is_path:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -27,7 +27,7 @@ class SubsetTestCase(TestCase):
             supValue = sup[subKey]
 
             if isinstance(subValue, str):
-                self.assertEquals(subValue, supValue)
+                self.assertEqual(subValue, supValue)
                 continue
 
             if isinstance(subValue, dict):
@@ -41,7 +41,7 @@ class SubsetTestCase(TestCase):
                     for subItem in subValue
                 ))
             except TypeError:
-                self.assertEquals(subValue, supValue)
+                self.assertEqual(subValue, supValue)
 
 
 def clean(path):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -157,7 +157,7 @@ def yaml_dashed_list(items, indent=0):
 
 def create_fake_config(directory, configname='config.yaml',
                        dotpath='dotfiles', backup=True, create=True,
-                       import_profiles=()):
+                       import_configs=()):
     """Create a fake config file"""
     path = os.path.join(directory, configname)
     workdir = os.path.join(directory, 'workdir')
@@ -167,9 +167,9 @@ def create_fake_config(directory, configname='config.yaml',
         f.write('  create: {}\n'.format(str(create)))
         f.write('  dotpath: {}\n'.format(dotpath))
         f.write('  workdir: {}\n'.format(workdir))
-        if import_profiles:
-            f.write('  import_profiles:\n')
-            f.write(yaml_dashed_list(import_profiles, 4))
+        if import_configs:
+            f.write('  import_configs:\n')
+            f.write(yaml_dashed_list(import_configs, 4))
         f.write('dotfiles:\n')
         f.write('profiles:\n')
         f.write('actions:\n')

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -242,3 +242,24 @@ def populate_fake_config(config, dotfiles={}, profiles={}, actions={},
         with open(config_path, 'w') as config_file:
             yaml.safe_dump(config, config_file, default_flow_style=False,
                            indent=2)
+
+
+def file_in_yaml(yaml_file, path, link=False):
+    """Return whether path is in the given yaml file as a dotfile."""
+    strip = get_path_strip_version(path)
+
+    if isinstance(yaml_file, str):
+        with open(yaml_file) as f:
+            yaml_conf = yaml.safe_load(f)
+    else:
+        yaml_conf = yaml_file
+
+    dotfiles = yaml_conf['dotfiles'].values()
+
+    in_src = strip in (x['src'] for x in dotfiles)
+    in_dst = path in (os.path.expanduser(x['dst']) for x in dotfiles)
+
+    if link:
+        has_link = get_dotfile_from_yaml(yaml_conf, path)['link']
+        return in_src and in_dst and has_link
+    return in_src and in_dst

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -226,10 +226,32 @@ profiles:
         vars_ed_file = create_yaml_keyval(vars_ed, tmp)
         vars_ing_file = create_yaml_keyval(vars_ing, tmp)
 
+        actions_ed = {
+            'pre': {
+                'a_pre_action_ed': 'echo pre 22',
+            },
+            'post': {
+                'a_post_action_ed': 'echo post 22',
+            },
+            'a_action_ed': 'echo 22',
+        }
+        actions_ing = {
+            'pre': {
+                'a_pre_action_ing': 'echo pre aa',
+            },
+            'post': {
+                'a_post_action_ing': 'echo post aa',
+            },
+            'a_action_ing': 'echo aa',
+        }
+        actions_ed_file = create_yaml_keyval(actions_ed, tmp)
+        actions_ing_file = create_yaml_keyval(actions_ing, tmp)
+
         imported = {
             'config': {
                 'dotpath': 'importing',
                 'import_variables': [vars_ed_file],
+                'import_actions': [actions_ed_file],
             },
             'dotfiles': {
                 'f_vimrc': {'dst': '~/.vimrc', 'src': 'vimrc'},
@@ -265,6 +287,7 @@ profiles:
             'config': {
                 'dotpath': 'importing',
                 'import_variables': [vars_ing_file],
+                'import_actions': [actions_ing_file],
             },
             'dotfiles': {
                 'f_xinitrc': {'dst': '~/.xinitrc', 'src': 'xinitrc'},
@@ -328,10 +351,6 @@ profiles:
         self.assertIsNotNone(importing_cfg)
         self.assertIsNotNone(imported_cfg)
 
-        # test settings
-        self.assertIsSubset(imported_cfg.lnk_settings,
-                            importing_cfg.lnk_settings)
-
         # test profiles
         self.assertIsSubset(imported_cfg.lnk_profiles,
                             importing_cfg.lnk_profiles)
@@ -365,14 +384,6 @@ profiles:
         # test prodots
         self.assertIsSubset(imported_cfg.prodots, importing_cfg.prodots)
 
-        # test ext_variables (reduntant, but still)
-        self.assertIsSubset(imported_cfg.ext_variables,
-                            importing_cfg.ext_variables)
-
-        # test ext_dynvariables (reduntant, but still)
-        self.assertIsSubset(imported_cfg.ext_dynvariables,
-                            importing_cfg.ext_dynvariables)
-
     def test_import_configs_override(self):
         """Test import_configs when some config keys overlap."""
         tmp = get_tempdir()
@@ -398,11 +409,33 @@ profiles:
         vars_ed_file = create_yaml_keyval(vars_ed, tmp)
         vars_ing_file = create_yaml_keyval(vars_ing, tmp)
 
+        actions_ed = {
+            'pre': {
+                'a_pre_action': 'echo pre 22',
+            },
+            'post': {
+                'a_post_action': 'echo post 22',
+            },
+            'a_action': 'echo 22',
+        }
+        actions_ing = {
+            'pre': {
+                'a_pre_action': 'echo pre aa',
+            },
+            'post': {
+                'a_post_action': 'echo post aa',
+            },
+            'a_action': 'echo aa',
+        }
+        actions_ed_file = create_yaml_keyval(actions_ed, tmp)
+        actions_ing_file = create_yaml_keyval(actions_ing, tmp)
+
         imported = {
             'config': {
                 'dotpath': 'imported',
                 'backup': False,
                 'import_variables': [vars_ed_file],
+                'import_actions': [actions_ed_file],
             },
             'dotfiles': {
                 'f_vimrc': {'dst': '~/.vimrc', 'src': 'vimrc'},
@@ -444,6 +477,7 @@ profiles:
                 'dotpath': 'importing',
                 'backup': True,
                 'import_variables': [vars_ing_file],
+                'import_actions': [actions_ing_file],
             },
             'dotfiles': {
                 'f_xinitrc': {'dst': '~/.xinitrc', 'src': 'xinitrc'},
@@ -507,12 +541,6 @@ profiles:
         self.assertIsNotNone(importing_cfg)
         self.assertIsNotNone(imported_cfg)
 
-        # test settings
-        self.assertTrue(importing_cfg.lnk_settings['dotpath']
-                        .endswith(importing['config']['dotpath']))
-        self.assertEqual(importing_cfg.lnk_settings['backup'],
-                         importing['config']['backup'])
-
         # test profiles
         self.assertIsSubset(imported_cfg.lnk_profiles,
                             importing_cfg.lnk_profiles)
@@ -560,19 +588,6 @@ profiles:
                             importing_cfg.prodots['host2'])
         self.assertTrue(set(imported_cfg.prodots['host1'])
                         < set(importing_cfg.prodots['host2']))
-
-        # test ext_variables (reduntant, but still)
-        self.assertFalse(any(
-            imported_cfg.ext_variables[key] == importing_cfg.ext_variables[key]
-            for key in imported_cfg.ext_variables
-        ))
-
-        # test ext_dynvariables (reduntant, but still)
-        self.assertFalse(any(
-            (imported_cfg.ext_dynvariables[key]
-                == importing_cfg.ext_dynvariables[key])
-            for key in imported_cfg.ext_dynvariables
-        ))
 
 
 def main():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -305,7 +305,7 @@ profiles:
         # create the importing base config file
         importing_path = create_fake_config(tmp,
                                             configname=self.CONFIG_NAME,
-                                            import_configs=(imported_path,),
+                                            import_configs=('config-*.yaml',),
                                             **importing['config'])
 
         # edit the imported config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -217,7 +217,7 @@ profiles:
                                        dotpath=self.CONFIG_DOTPATH,
                                        backup=self.CONFIG_BACKUP,
                                        create=self.CONFIG_CREATE,
-                                       import_profiles=(imported,))
+                                       import_configs=(imported,))
 
         # keys
         keys = {

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -39,8 +39,8 @@ class TestImport(unittest.TestCase):
     def assert_file(self, path, o, profile):
         """Make sure path has been inserted in conf for profile"""
         strip = get_path_strip_version(path)
-        self.assertTrue(strip in [x.src for x in o.dotfiles])
-        dsts = [os.path.expanduser(x.dst) for x in o.dotfiles]
+        self.assertTrue(any(x.src.endswith(strip) for x in o.dotfiles))
+        dsts = (os.path.expanduser(x.dst) for x in o.dotfiles)
         self.assertTrue(path in dsts)
 
     def assert_in_yaml(self, path, dic, link=False):

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -15,10 +15,10 @@ from dotdrop.dotdrop import cmd_list_files
 from dotdrop.dotdrop import cmd_update
 from dotdrop.linktypes import LinkTypes
 
-from tests.helpers import get_path_strip_version, edit_content, \
-                          load_options, create_random_file, \
-                          clean, get_string, get_dotfile_from_yaml, \
-                          get_tempdir, create_fake_config, create_dir
+from tests.helpers import (clean, create_dir, create_fake_config,
+                           create_random_file, edit_content, file_in_yaml,
+                           get_path_strip_version, get_string, get_tempdir,
+                           load_options, populate_fake_config)
 
 
 class TestImport(unittest.TestCase):
@@ -45,12 +45,7 @@ class TestImport(unittest.TestCase):
 
     def assert_in_yaml(self, path, dic, link=False):
         """Make sure "path" is in the "dic" representing the yaml file"""
-        strip = get_path_strip_version(path)
-        self.assertTrue(strip in [x['src'] for x in dic['dotfiles'].values()])
-        dsts = [os.path.expanduser(x['dst']) for x in dic['dotfiles'].values()]
-        if link:
-            self.assertTrue(get_dotfile_from_yaml(dic, path)['link'])
-        self.assertTrue(path in dsts)
+        self.assertTrue(file_in_yaml(dic, path, link))
 
     def test_import(self):
         """Test the import function"""
@@ -202,6 +197,210 @@ class TestImport(unittest.TestCase):
         cmd_update(o)
         c2 = open(indt1, 'r').read()
         self.assertTrue(editcontent == c2)
+
+    def test_ext_config_yaml_not_mix(self):
+        """Test whether the import_configs mixes yaml files upon importing."""
+        # dotfiles on filesystem
+        src = get_tempdir()
+        self.assertTrue(os.path.exists(src))
+        self.addCleanup(clean, src)
+
+        # create some random dotfiles
+        dotfiles = []
+        for _ in range(3):
+            dotfile, _ = create_random_file(src)
+            dotfiles.append(dotfile)
+            self.addCleanup(clean, dotfile)
+        self.assertTrue(all(map(os.path.exists, dotfiles)))
+
+        # create dotdrop home
+        dotdrop_home = get_tempdir()
+        self.assertTrue(os.path.exists(dotdrop_home))
+        self.addCleanup(clean, dotdrop_home)
+
+        imported = {
+            'config': {
+                'dotpath': 'imported',
+            },
+            'dotfiles': {},
+            'profiles': {
+                'host1': {
+                    'dotfiles': [],
+                },
+            },
+            'actions': {
+                'pre': {
+                    'a_pre_log_ed': 'echo pre 2',
+                },
+                'post': {
+                    'a_post_log_ed': 'echo post 2',
+                },
+                'a_log_ed': 'echo 2',
+            },
+            'trans': {
+                't_log_ed': 'echo 3',
+            },
+            'trans_write': {
+                'tw_log_ed': 'echo 4',
+            },
+            'variables': {
+                'v_log_ed': '42',
+            },
+            'dynvariables': {
+                'dv_log_ed': 'echo 5',
+            },
+        }
+        importing = {
+            'config': {
+                'dotpath': 'importing',
+            },
+            'dotfiles': {},
+            'profiles': {
+                'host2': {
+                    'dotfiles': [],
+                    'include': ['host1'],
+                },
+            },
+            'actions': {
+                'pre': {
+                    'a_pre_log_ing': 'echo pre a',
+                },
+                'post': {
+                    'a_post_log_ing': 'echo post a',
+                },
+                'a_log_ing': 'echo a',
+            },
+            'trans': {
+                't_log_ing': 'echo b',
+            },
+            'trans_write': {
+                'tw_log_ing': 'echo c',
+            },
+            'variables': {
+                'v_log_ing': 'd',
+            },
+            'dynvariables': {
+                'dv_log_ing': 'echo e',
+            },
+        }
+
+        dotfiles_ing, dotfiles_ed = dotfiles[:-1], dotfiles[-1:]
+
+        # create the imported base config file
+        imported_path = create_fake_config(dotdrop_home,
+                                           configname='config-2.yaml',
+                                           **imported['config'])
+        # create the importing base config file
+        importing_path = create_fake_config(dotdrop_home,
+                                            configname='config.yaml',
+                                            import_configs=('config-*.yaml',),
+                                            **importing['config'])
+
+        # edit the imported config
+        populate_fake_config(imported_path, **{
+            k: v
+            for k, v in imported.items()
+            if k != 'config'
+        })
+
+        # edit the importing config
+        populate_fake_config(importing_path, **{
+            k: v
+            for k, v in importing.items()
+            if k != 'config'
+        })
+
+        # import the dotfiles
+        o = load_options(imported_path, 'host1')
+        o.import_path = dotfiles_ed
+        cmd_importer(o)
+
+        o = load_options(importing_path, 'host2')
+        o.import_path = dotfiles_ing
+        cmd_importer(o)
+
+        # reload the config
+        o = load_options(importing_path, 'host2')
+
+        # test imported config
+        y = self.load_yaml(imported_path)
+
+        # testing dotfiles
+        self.assertTrue(all(file_in_yaml(y, df) for df in dotfiles_ed))
+        self.assertFalse(any(file_in_yaml(y, df) for df in dotfiles_ing))
+
+        # testing profiles
+        profiles = y['profiles'].keys()
+        self.assertTrue('host1' in profiles)
+        self.assertFalse('host2' in profiles)
+
+        # testing actions
+        actions = y['actions']['pre']
+        actions.update(y['actions']['post'])
+        actions.update({
+            k: v
+            for k, v in y['actions'].items()
+            if k not in ('pre', 'post')
+        })
+        actions = actions.keys()
+        self.assertTrue(all(a.endswith('ed') for a in actions))
+        self.assertFalse(any(a.endswith('ing') for a in actions))
+
+        # testing transformations
+        transformations = y['trans'].keys()
+        self.assertTrue(all(t.endswith('ed') for t in transformations))
+        self.assertFalse(any(t.endswith('ing') for t in transformations))
+        transformations = y['trans_write'].keys()
+        self.assertTrue(all(t.endswith('ed') for t in transformations))
+        self.assertFalse(any(t.endswith('ing') for t in transformations))
+
+        # testing variables
+        variables = y['variables'].keys()
+        self.assertTrue(all(v.endswith('ed') for v in variables))
+        self.assertFalse(any(v.endswith('ing') for v in variables))
+        dyn_variables = y['dynvariables'].keys()
+        self.assertTrue(all(dv.endswith('ed') for dv in dyn_variables))
+        self.assertFalse(any(dv.endswith('ing') for dv in dyn_variables))
+
+        # test importing config
+        y = self.load_yaml(importing_path)
+
+        # testing dotfiles
+        self.assertTrue(all(file_in_yaml(y, df) for df in dotfiles_ing))
+        self.assertFalse(any(file_in_yaml(y, df) for df in dotfiles_ed))
+
+        # testing profiles
+        profiles = y['profiles'].keys()
+        self.assertTrue('host2' in profiles)
+        self.assertFalse('host1' in profiles)
+
+        # testing actions
+        actions = y['actions']['pre']
+        actions.update(y['actions']['post'])
+        actions.update({
+            k: v
+            for k, v in y['actions'].items()
+            if k not in ('pre', 'post')
+        })
+        actions = actions.keys()
+        self.assertTrue(all(action.endswith('ing') for action in actions))
+        self.assertFalse(any(action.endswith('ed') for action in actions))
+
+        # testing transformations
+        transformations = y['trans'].keys()
+        self.assertTrue(all(t.endswith('ing') for t in transformations))
+        self.assertFalse(any(t.endswith('ed') for t in transformations))
+        transformations = y['trans_write'].keys()
+        self.assertTrue(all(t.endswith('ing') for t in transformations))
+        self.assertFalse(any(t.endswith('ed') for t in transformations))
+
+        # testing variables
+        variables = y['variables'].keys()
+        self.assertTrue(all(v.endswith('ing') for v in variables))
+        self.assertFalse(any(v.endswith('ed') for v in variables))
+        dyn_variables = y['dynvariables'].keys()
+        self.assertTrue(all(dv.endswith('ing') for dv in dyn_variables))
+        self.assertFalse(any(dv.endswith('ed') for dv in dyn_variables))
 
 
 def main():


### PR DESCRIPTION
Here we come, the `import_configs` functionality we talked about in #113. Just as a brief recap, we have a new config key, `import_configs` which will merge in the content of one or more configuration files. Some details:
- Conflicting keys (defined in both configs, like dotfiles or profiles having the same name), are resolved by keeping the original value, the one from the _importing_ config file.
- Shell globs can be used to specify config file paths, which as usual are relative to the _importing_ config file.

Now, some notes about the pull request itself:
- The first two commits are refactoring in the `Cfg._parse` method. The first one uses stuff such as `dict.setdefault` and `dict.get` to remove some `if`conditions on dictionary keys. The second one uses the more Pythonic `try .. catch KeyError` (_ask for forgiveness not for permission_) to check if a key is defined and then provide a default if its value is `None`. However, it's not very readable, so it's better to assess whether it should be included to begin with.
- Beside the typos in the commit messages, the rest is pretty straightforward: external configs are recursively parsed by constructing a `Cfg` class and then the two `Cfg` objects are merged in the [`_merge_cfg`](https://github.com/davla/dotdrop/blob/import-config/dotdrop/config.py#L453) method, by merging dictionaries and lists instance members.
- Globbing uses the `recursive` flag in [`iglob`](https://docs.python.org/3.7/library/glob.html#glob.iglob). It's been introduced in Python 3.5, but I think this is not a problem.