### PR TITLE
[hotfix] imported configs variables were not merged in

### DIFF
--- a/dotdrop/config.py
+++ b/dotdrop/config.py
@@ -610,12 +610,12 @@ class Cfg:
         variables = {
             k: v
             for k, v in ext_config._get_variables(None).items()
-            if k not in self.content[self.key_variables]
+            if k not in self._get_variables(None).keys()
         }
         dyn_variables = {
             k: v
             for k, v in ext_config._get_dynvariables(None).items()
-            if k not in self.content[self.key_dynvariables]
+            if k not in self._get_dynvariables(None).keys()
         }
         self._merge_dict(ext_config=ext_config, warning_prefix='Variable',
                          self_member=self.ext_variables,


### PR DESCRIPTION
So, I don't know why at all, but in the external configs merge, this line in a dict comprehension
```python
if k not in self.content[self.key_variables]
```
Somehow made the method jump straight to the end, skipping all subsequent lines :astonished: As a result, some variables were not actually imported, and even more mysteriously, this solves the issue:
```python
if k not in self._get_variables(None).keys()
```
I believe that this kind of problem will not occur after the ongoing refactoring, so there's no point in actually investigating the causes. We can be happy with this hotfix.

Just for the records, I have my main [`config-user.yaml`](https://github.com/davla/dotfiles/blob/4a9c93016ec87630e8ea73aa10398a76ab3bd77d/config-user.yaml), which imports the config [`profiles.d/zsh.yaml`](https://github.com/davla/dotfiles/blob/4a9c93016ec87630e8ea73aa10398a76ab3bd77d/profiles.d/zsh.yaml). This defines the dynamic variable `actions_path`, that is used nowhere else than in the `zsh` post action, defined and used only in `profiles.d/zsh.yaml` itself.  
Apparently, the dynamic variable in the action is only interpolated in the main `config-user.yaml`, rather that occurring recursively in `profiles.d/zsh.yaml`. Again, this will be changed and addressed properly in the ongoing refactoring, so no worries.