### PR TITLE
installer: link_children links deep files

### DIFF
--- a/dotdrop/installer.py
+++ b/dotdrop/installer.py
@@ -173,7 +173,12 @@ class Installer:
             os.unlink(dst)
             os.mkdir(dst)
 
-        children = os.listdir(parent)
+        os.chdir(parent)
+        children = []
+        for folder, subfolders, files in os.walk(parent):
+            for file in files:
+                children.append(os.path.join(os.path.relpath(folder), file))
+
         srcs = [os.path.normpath(os.path.join(parent, child))
                 for child in children]
         dsts = [os.path.normpath(os.path.join(dst, child))
@@ -182,6 +187,11 @@ class Installer:
         for i in range(len(children)):
             src = srcs[i]
             dst = dsts[i]
+
+            dstdir = os.path.dirname(os.path.expanduser(dst))
+            if not os.path.lexists(dstdir):
+                self.log.sub('creating directory "{}"'.format(dstdir))
+                os.makedirs(dstdir)
 
             if self.debug:
                 self.log.dbg('symlink child {} to {}'.format(src, dst))


### PR DESCRIPTION
First off thanks for such a cool project!

I have a multi-machine configuration with the following simplified hierarchy:

    dotfiles/y/b/c/1
    dotfiles/x/b/c/2

And would like the result:

    ls /target/b/c/
    1 -> dotfiles/y/b/c/1
    2 -> dotfiles/x/b/c/2

Does this make sense?

As I understand it `link_children` only symlinks _direct_ children - which caused `/target/b` (`-> dotfiles/x/b/c/1`) to be overridden by `dotfiles/y/b/c/1`.

Only one of my sources could be managed at a time.

The following patch links all child files regardless of depth and creates any necessary directories when using `link_children`. Now this is by no means production quality code but it solved the problems I was having.

I tried using the regular `link` option but I have quite a few files and manually selecting every file is a bit tedious.

A few questions before I go any deeper down the rabbit hole:

1. Is this the right way to go on about it or am I missing something?
2. Would it be reasonable to create another link option with features similiar to this patch? I also thought of adding a `depth` option to `link_children` but was not satisfied with the result.

For reference my configuration can be found [here](https://github.com/hallabro/dotfiles/blob/master/global-config.yaml).