### PR TITLE
[bug] Variables not expanded in profile actions

### DIFF
--- a/dotdrop/cfg_yaml.py
+++ b/dotdrop/cfg_yaml.py
@@ -244,6 +244,21 @@ class CfgYaml:
                     self.log.dbg('resolved: {}'.format(new))
                 v[self.key_dotfile_actions] = new
 
+        # profile entries
+        try:
+            this_profile = self.profiles[self.profile]
+            # actions
+            this_profile[self.key_profile_actions] = [
+                t.generate_string(a)
+                for a in this_profile.get(self.key_profile_actions, [])
+            ]
+            this_profile_actions = this_profile[self.key_profile_actions]
+            if this_profile_actions and self.debug:
+                self.log.dbg('resolved: {}'.format(this_profile_actions))
+        except KeyError:
+            # self.profile is not in the YAML file
+            pass
+
         # external actions paths
         new = []
         for p in self.settings.get(self.key_import_actions, []):

--- a/tests-ng/actions-args-template.sh
+++ b/tests-ng/actions-args-template.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# author: deadc0de6 (https://github.com/deadc0de6)
+# Copyright (c) 2017, deadc0de6
+#
+# test action template execution
+# returns 1 in case of error
+#
+
+# exit on first error
+set -e
+
+# all this crap to get current path
+rl="readlink -f"
+if ! ${rl} "${0}" >/dev/null 2>&1; then
+  rl="realpath"
+
+  if ! hash ${rl}; then
+    echo "\"${rl}\" not found !" && exit 1
+  fi
+fi
+cur=$(dirname "$(${rl} "${0}")")
+
+#hash dotdrop >/dev/null 2>&1
+#[ "$?" != "0" ] && echo "install dotdrop to run tests" && exit 1
+
+#echo "called with ${1}"
+
+# dotdrop path can be pass as argument
+ddpath="${cur}/../"
+[ "${1}" != "" ] && ddpath="${1}"
+[ ! -d ${ddpath} ] && echo "ddpath \"${ddpath}\" is not a directory" && exit 1
+
+export PYTHONPATH="${ddpath}:${PYTHONPATH}"
+bin="python3 -m dotdrop.dotdrop"
+
+echo "dotdrop path: ${ddpath}"
+echo "pythonpath: ${PYTHONPATH}"
+
+# get the helpers
+source ${cur}/helpers
+
+echo -e "\e[96m\e[1m==> RUNNING $(basename $BASH_SOURCE) <==\e[0m"
+
+################################################################
+# this is the test
+################################################################
+
+# the action temp
+tmpa=`mktemp -d --suffix='-dotdrop-tests'`
+# the dotfile source
+tmps=`mktemp -d --suffix='-dotdrop-tests'`
+mkdir -p ${tmps}/dotfiles
+# the dotfile destination
+tmpd=`mktemp -d --suffix='-dotdrop-tests'`
+
+# create the config file
+cfg="${tmps}/config.yaml"
+
+cat > ${cfg} << _EOF
+actions:
+  pre:
+    preaction: "echo {0} > {1}"
+  post:
+    postaction: "echo {0} > ${tmpa}/post"
+  nakedaction: "echo {0} > ${tmpa}/naked"
+  profileaction: "echo {0} > ${tmpa}/profile"
+  dynaction: "echo {0} > ${tmpa}/dyn"
+config:
+  backup: true
+  create: true
+  dotpath: dotfiles
+  default_actions:
+  - preaction '{{@@ var_pre @@}}' "${tmpa}/pre"
+  - postaction '{{@@ var_post @@}}'
+  - nakedaction '{{@@ var_naked @@}}'
+dotfiles:
+  f_abc:
+    dst: ${tmpd}/abc
+    src: abc
+profiles:
+  p1:
+    dotfiles:
+    - f_abc
+    actions:
+    - profileaction '{{@@ var_profile @@}}'
+    - dynaction '{{@@ user_name @@}}'
+variables:
+  var_pre: var_pre
+  var_post: var_post
+  var_naked: var_naked
+  var_profile: var_profile
+dynvariables:
+  user_name: 'echo $USER'
+_EOF
+#cat ${cfg}
+
+# create the dotfile
+echo 'test' > ${tmps}/dotfiles/abc
+
+# install
+cd ${ddpath} | ${bin} install -f -c ${cfg} -p p1 -V
+
+# checks action
+[ ! -e ${tmpa}/pre ] && echo 'pre action not executed' && exit 1
+[ ! -e ${tmpa}/post ] && echo 'post action not executed' && exit 1
+[ ! -e ${tmpa}/naked ] && echo 'naked action not executed'  && exit 1
+[ ! -e ${tmpa}/profile ] && echo 'profile action not executed'  && exit 1
+[ ! -e ${tmpa}/dyn ] && echo 'dynamic acton action not executed'  && exit 1
+grep var_pre ${tmpa}/pre >/dev/null
+grep var_post ${tmpa}/post >/dev/null
+grep var_naked ${tmpa}/naked >/dev/null
+grep var_profile ${tmpa}/profile >/dev/null
+grep "$USER" ${tmpa}/dyn >/dev/null
+
+## CLEANING
+rm -rf ${tmps} ${tmpd} ${tmpa}
+
+echo "OK"
+exit 0

--- a/tests.sh
+++ b/tests.sh
@@ -37,9 +37,15 @@ PYTHONPATH=dotdrop ${nosebin} -s --with-coverage --cover-package=dotdrop
 [ "$1" = '--python-only' ] || {
   log=`mktemp`
   for scr in tests-ng/*.sh; do
-    ${scr} 2>&1 | tee ${log}
+    ${scr} > "${log}" 2>&1 &
+    tail --pid="$!" -f "${log}"
     set +e
-    if grep Traceback ${log}; then
+    wait "$!"
+    if [ "$?" -ne 0 ]; then
+        echo "Test ${scr} finished with error"
+        rm -f ${log}
+        exit 1
+    elif grep Traceback ${log}; then
       echo "crash found in logs"
       rm -f ${log}
       exit 1


### PR DESCRIPTION
Variables were not expanded in profile actions. Simply, there was no code for that :smile:. I added it in `cfg_yaml.py`, you can see it in the diff.

I also added a specific shell test targeted specifically to action arguments using templating. This "creates" another bug. Indeed, in `tests.sh` the exit code of shell tests was not checked, thus some tests "failed to fail" :laughing:. I added this check, and now `dynextvariables.sh` fails. Looks like we'll have some other bugs to fix.

You can notice in the diff that checking the exit status of shell tests is convoluted. This is because we cannot pipe the script to `tee` any longer, as POSIX shell provides no way of checking the exit status of any commands in a pipe but the last. In other words, `$?` would be the exit of `tee`. Luckily enough, I knew a trick already :smile: Here it is explained:

https://github.com/davla/dotdrop/blob/master/tests.sh#L40-L44
- On line 40, we start the shell test as a *background* process, redirecting stdout to the log file.
- On line 41, we display the log file live with `tail -f`. `--pid="$!"` makes `tail` exit as soon as the last background process (in our case the shell test) terminates,
- On line 43, we synchronize with the last background process (again, the shell test). This has the side effect of placing the last background process exit status in `$?` (For the sake of completeness, this `wait` doesn't imply any waiting time, as the shell test has terminated once we get here, since `tail` wouldn't terminate before the shell test)
- On line 44, we finally check the shell test exit status.

