### PR TITLE
Unexpanded variables

### DIFF
--- a/dotdrop/cfg_yaml.py
+++ b/dotdrop/cfg_yaml.py
@@ -269,6 +269,16 @@ class CfgYaml:
                 # making sure that this generic name doesn't stay in scope
                 del actions
 
+        # settings entries
+        self.settings[Settings.key_default_actions] = [
+            t.generate_string(a)
+            for a in self.settings.get(Settings.key_default_actions, ())
+        ]
+        if self.debug:
+            default_actions = self.settings[Settings.key_default_actions]
+            if default_actions:
+                self.log.dbg('resolved: {}'.format(default_actions))
+
         # external actions paths
         new = []
         for p in self.settings.get(self.key_import_actions, []):

--- a/dotdrop/cfg_yaml.py
+++ b/dotdrop/cfg_yaml.py
@@ -245,19 +245,29 @@ class CfgYaml:
                 v[self.key_dotfile_actions] = new
 
         # profile entries
-        try:
-            this_profile = self.profiles[self.profile]
-            # actions
-            this_profile[self.key_profile_actions] = [
-                t.generate_string(a)
-                for a in this_profile.get(self.key_profile_actions, [])
+        for profile in self.profiles.values():
+            # external dotfiles
+            profile[self.key_import_profile_dfs] = [
+                t.generate_string(dfs)
+                for dfs in profile.get(self.key_import_profile_dfs, [])
             ]
-            this_profile_actions = this_profile[self.key_profile_actions]
-            if this_profile_actions and self.debug:
-                self.log.dbg('resolved: {}'.format(this_profile_actions))
-        except KeyError:
-            # self.profile is not in the YAML file
-            pass
+            # actions
+            profile[self.key_profile_actions] = [
+                t.generate_string(a)
+                for a in profile.get(self.key_profile_actions, [])
+            ]
+
+            if self.debug:
+                imported_dotfiles = profile[self.key_import_profile_dfs]
+                actions = profile[self.key_profile_actions]
+
+                if imported_dotfiles:
+                    self.log.dbg('resolved: {}'.format(imported_dotfiles))
+                if actions:
+                    self.log.dbg('resolved: {}'.format(actions))
+
+                # making sure that this generic name doesn't stay in scope
+                del actions
 
         # external actions paths
         new = []
@@ -285,16 +295,6 @@ class CfgYaml:
             if self.debug:
                 self.log.dbg('resolved: {}'.format(new))
             self.settings[self.key_import_variables] = new
-
-        # external profiles dotfiles
-        for k, v in self.profiles.items():
-            new = []
-            for p in v.get(self.key_import_profile_dfs, []):
-                new.append(t.generate_string(p))
-            if new:
-                if self.debug:
-                    self.log.dbg('resolved: {}'.format(new))
-                v[self.key_import_profile_dfs] = new
 
         return allvars
 

--- a/tests-ng/actions-args-template.sh
+++ b/tests-ng/actions-args-template.sh
@@ -63,7 +63,7 @@ actions:
   post:
     postaction: "echo {0} > ${tmpa}/post"
   nakedaction: "echo {0} > ${tmpa}/naked"
-  profileaction: "echo {0} > ${tmpa}/profile"
+  profileaction: "echo {0} >> ${tmpa}/profile"
   dynaction: "echo {0} > ${tmpa}/dyn"
 config:
   backup: true
@@ -84,11 +84,20 @@ profiles:
     actions:
     - profileaction '{{@@ var_profile @@}}'
     - dynaction '{{@@ user_name @@}}'
+    include:
+    - p2
+  p2:
+    dotfiles:
+    - f_abc
+    actions:
+    - profileaction '{{@@ var_profile_2 @@}}'
+    variables:
+      var_profile_2: profile_var_2
 variables:
-  var_pre: var_pre
-  var_post: var_post
-  var_naked: var_naked
-  var_profile: var_profile
+  var_pre: pre_var
+  var_post: post_var
+  var_naked: naked_var
+  var_profile: profile_var
 dynvariables:
   user_name: 'echo $USER'
 _EOF
@@ -106,10 +115,11 @@ cd ${ddpath} | ${bin} install -f -c ${cfg} -p p1 -V
 [ ! -e ${tmpa}/naked ] && echo 'naked action not executed'  && exit 1
 [ ! -e ${tmpa}/profile ] && echo 'profile action not executed'  && exit 1
 [ ! -e ${tmpa}/dyn ] && echo 'dynamic acton action not executed'  && exit 1
-grep var_pre ${tmpa}/pre >/dev/null
-grep var_post ${tmpa}/post >/dev/null
-grep var_naked ${tmpa}/naked >/dev/null
-grep var_profile ${tmpa}/profile >/dev/null
+grep pre_var ${tmpa}/pre >/dev/null
+grep post_var ${tmpa}/post >/dev/null
+grep naked_var ${tmpa}/naked >/dev/null
+grep profile_var ${tmpa}/profile >/dev/null
+grep profile_var_2 ${tmpa}/profile >/dev/null
 grep "$USER" ${tmpa}/dyn >/dev/null
 
 ## CLEANING


### PR DESCRIPTION
So, it looks like variables are also not expanded in `default_actions`. Maybe also somewhere else, like `upignore` or `cmpignore`. Any other ideas @deadc0de6?

Also, I realized that in #162 I only expanded variables for the current profile, rather than all of them :sweat_smile: Furthermore, the test was very badly engineered. Variables names were the same as the content, so `grep` would succeed regardless of expansion :scream:. Way too rushed as a PR, definitely.