### PR TITLE
Action-args-template tests + included profile variables

### DIFF
--- a/tests-ng/actions-args-template.sh
+++ b/tests-ng/actions-args-template.sh
@@ -45,6 +45,20 @@ echo -e "\e[96m\e[1m==> RUNNING $(basename $BASH_SOURCE) <==\e[0m"
 # this is the test
 ################################################################
 
+# Convenience function to grep into a file and exit with an erro message if the
+# content is not found
+should_grep() {
+    SHOULD_GREP_STR="$1"
+    SHOULD_GREP_FILE="$2"
+
+    grep "$SHOULD_GREP_STR" "$SHOULD_GREP_FILE" > /dev/null || {
+        echo >&2 "$SHOULD_GREP_STR not found in $SHOULD_GREP_FILE"
+        exit 1
+    }
+
+    unset SHOULD_GREP_FILE SHOULD_GREP_STR
+}
+
 # the action temp
 tmpa=`mktemp -d --suffix='-dotdrop-tests'`
 # the dotfile source
@@ -63,7 +77,7 @@ actions:
   post:
     postaction: "echo {0} > ${tmpa}/post"
   nakedaction: "echo {0} > ${tmpa}/naked"
-  profileaction: "echo {0} > ${tmpa}/profile"
+  profileaction: "echo {0} >> ${tmpa}/profile"
   dynaction: "echo {0} > ${tmpa}/dyn"
 config:
   backup: true
@@ -84,11 +98,20 @@ profiles:
     actions:
     - profileaction '{{@@ var_profile @@}}'
     - dynaction '{{@@ user_name @@}}'
+    include:
+    - p2
+  p2:
+    dotfiles:
+    - f_abc
+    actions:
+    - profileaction '{{@@ var_profile_2 @@}}'
+    variables:
+      var_profile_2: profile_var_2
 variables:
-  var_pre: abc
-  var_post: def
-  var_naked: ghi
-  var_profile: jkl
+  var_pre: pre_var
+  var_post: post_var
+  var_naked: naked_var
+  var_profile: profile_var
 dynvariables:
   user_name: 'echo $USER'
 _EOF
@@ -106,16 +129,12 @@ cd ${ddpath} | ${bin} install -f -c ${cfg} -p p1 -V
 [ ! -e ${tmpa}/naked ] && echo 'naked action not executed'  && exit 1
 [ ! -e ${tmpa}/profile ] && echo 'profile action not executed'  && exit 1
 [ ! -e ${tmpa}/dyn ] && echo 'dynamic acton action not executed'  && exit 1
-cat ${tmpa}/pre
-grep abc ${tmpa}/pre >/dev/null
-cat ${tmpa}/post
-grep def ${tmpa}/post >/dev/null
-cat ${tmpa}/naked
-grep ghi ${tmpa}/naked >/dev/null
-cat ${tmpa}/profile
-grep jkl ${tmpa}/profile >/dev/null
-cat ${tmpa}/dyn
-grep "$USER" ${tmpa}/dyn >/dev/null
+should_grep pre_var ${tmpa}/pre
+should_grep post_var ${tmpa}/post
+should_grep naked_var ${tmpa}/naked
+should_grep profile_var ${tmpa}/profile
+should_grep profile_var_2 ${tmpa}/profile
+should_grep "$USER" ${tmpa}/dyn
 
 ## CLEANING
 rm -rf ${tmps} ${tmpd} ${tmpa}


### PR DESCRIPTION
I came up with this test for action-args-template a couple of days ago anyway, so we might as well use it.

It is a bit better than the previous one, as it checks whether profile variables are imported and expanded as well with `include`. And they're actually not imported, but they are expanded.

Unless there's a very good reason for this, I think it's very unexpected, and it probably makes profile inclusion not working, as profiles rely on their local variables. I can try to PR this, but I'm not  available until the weekend.

Btw, congratulations on fixing the shell tests.