### PR TITLE
add option to disable auto-updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ For MacOS users, make sure to install `realpath` through homebrew
 
 Using dotdrop as a submodule will need you to work with dotdrop by
 using the generated script `dotdrop.sh` at the root
-of your dotfiles repository.
+of your dotfiles repository. Note that this script updates the submodule
+automatically, unless called with the environment variable `DOTDROP_AUTOUPDATE`
+set to `no`.
 
 To ease the use of dotdrop, it is recommended to add an alias to it in your
 shell (*~/.bashrc*, *~/.zshrc*, etc) with the config file path, for example

--- a/dotdrop.sh
+++ b/dotdrop.sh
@@ -24,8 +24,10 @@ sub="dotdrop"
 # pivot
 cd "${cur}" || { echo "Directory \"${cur}\" doesn't exist, aborting." && exit 1; }
 # init/update the submodule
-git submodule update --init --recursive
-git submodule update --remote dotdrop
+if [ "${DOTDROP_AUTOUPDATE-yes}" = yes ] ; then
+  git submodule update --init --recursive
+  git submodule update --remote dotdrop
+fi
 # launch dotdrop
 PYTHONPATH=dotdrop python3 -m dotdrop.dotdrop "${args[@]}"
 ret="$?"


### PR DESCRIPTION
Previously, the wrapper script `dotdrop.sh` automatically updated the git submodules each time it was called. This is slow (especially so when network is unavailable) and undesirable for some (most?) people. I don’t want a production tool I rely on daily to suddenly break or to introduce incompatible changes without me asking for an update.

Now, it has an option to disable this automatic update.

To keep the current behavior, I left it enabled by default, but I _really_ think it should be off by default.

I am not quite satisfied with my implementation, as it seems odd from the user’s perspective: a more natural interface would be a command line switch `--autoupdate=[no|yes]`. But this has to be done from the wrapper script, whereas command line options are forwarded to the actual Python program. A compromise might be to require this option to be at the very first position in the command line, so that it can be consumed by the wrapper script. And to document it in `--help`.

So, this PR is more like a suggestion, so that you can decide what is the best option.

Thanks for this software!