### PR TITLE
Fixing no-assignment issue in _diff_before_write

### DIFF
--- a/dotdrop/installer.py
+++ b/dotdrop/installer.py
@@ -422,7 +422,8 @@ class Installer:
             tmp = utils.write_to_tmpfile(content)
             src = tmp
         diff = utils.diff(src, dst, raw=False)
-        utils.remove(tmp, quiet=True)
+        if tmp:
+            utils.remove(tmp, quiet=True)
 
         # fake the output for readability
         if not diff:


### PR DESCRIPTION
If content is None, then tmp is never created.
Need to check before calling utils.remove, which does not handle None as its input.

[There are more Pythonic ways to do this](https://docs.python.org/3.8/library/tempfile.html), but I don't want to submit a patch that redoes everything.