### PR TITLE
Fix diff order

### DIFF
--- a/dotdrop/comparator.py
+++ b/dotdrop/comparator.py
@@ -123,7 +123,7 @@ class Comparator:
 
     def _diff(self, left, right, header=False):
         """diff using the unix tool diff"""
-        out = diff(left, right, raw=False,
+        out = diff(modified=left, original=right, raw=False,
                    opts=self.diffopts, debug=self.debug)
         if header:
             lshort = os.path.basename(left)

--- a/dotdrop/installer.py
+++ b/dotdrop/installer.py
@@ -437,7 +437,7 @@ class Installer:
         if content:
             tmp = utils.write_to_tmpfile(content)
             src = tmp
-        diff = utils.diff(src, dst, raw=False)
+        diff = utils.diff(modified=src, original=dst, raw=False)
         if tmp:
             utils.remove(tmp, quiet=True)
 

--- a/dotdrop/installer.py
+++ b/dotdrop/installer.py
@@ -444,7 +444,7 @@ class Installer:
         # fake the output for readability
         if not diff:
             return
-        self.log.log('diff \"{}\" VS \"{}\"'.format(src, dst))
+        self.log.log('diff \"{}\" VS \"{}\"'.format(dst, src))
         self.log.emph(diff)
 
     def _create_dirs(self, directory):

--- a/dotdrop/utils.py
+++ b/dotdrop/utils.py
@@ -70,9 +70,9 @@ def shell(cmd, debug=False):
     return ret == 0, out
 
 
-def diff(src, dst, raw=True, opts='', debug=False):
+def diff(original, modified, raw=True, opts='', debug=False):
     """call unix diff to compare two files"""
-    cmd = 'diff -r {} \"{}\" \"{}\"'.format(opts, dst, src)
+    cmd = 'diff -r {} \"{}\" \"{}\"'.format(opts, original, modified)
     _, out = run(shlex.split(cmd), raw=raw, debug=debug)
     return out
 

--- a/dotdrop/utils.py
+++ b/dotdrop/utils.py
@@ -72,7 +72,7 @@ def shell(cmd, debug=False):
 
 def diff(src, dst, raw=True, opts='', debug=False):
     """call unix diff to compare two files"""
-    cmd = 'diff -r {} \"{}\" \"{}\"'.format(opts, src, dst)
+    cmd = 'diff -r {} \"{}\" \"{}\"'.format(opts, dst, src)
     _, out = run(shlex.split(cmd), raw=raw, debug=debug)
     return out
 


### PR DESCRIPTION
I've been having issues interpreting the diffs shown by Dotdrop since I set it as the default. After some investigation, it turns out the current usage is to compare source (modified) against the destination (file to overwrite).

This is confusing. It produces diffs as if you were going to apply destination on source, when you want the diff of what it would take to apply source on destination instead.

This is also what you would do if you were to generate and apply a diff patch manually:

```bash
diff destination.file modified.file > diff.patch
patch destination.file diff.patch
```

---

### Edit: This section null after I reverted that commit. Might be better suited for #203 

This PR also makes diffs show with the unified format. This is more of a personal preference, but I'd argue that pretty much every developer is going to be more familiar with the unified format and be able to interpret it more easily/quickly than the default diff format. This is because the unified format is what `git diff` uses. It's also arguably more explicit as well. As an example:

Default format:
```diff
diff "/tmp/dotdrop-egz8_ci9" VS "~/.i3/config"
1c1
< ## i3 config file (v4)
---
> # i3 config file (v4)
Overwrite "~/.i3/config" [y/N] ? 
```

Unified format
```diff
diff "~/.i3/config" VS "/tmp/dotdrop-b3xzkk21"
--- ~/.i3/config	2020-01-19 11:58:34.239286382 +0100
+++ /tmp/dotdrop-b3xzkk21	2020-01-19 20:22:23.154598928 +0100
@@ -1,4 +1,4 @@
-# i3 config file (v4)
+## i3 config file (v4)
 # Please see http://i3wm.org/docs/userguide.html for a complete reference!
 
 # Set mod key (Mod1=<Alt>, Mod4=<Super>)
Overwrite "~/.i3/config" [y/N] 
```

The default format here is using the original code, without any of these changes. This was to illustrate my earlier point where it looks as if you were applying destination on source.

Now, as for the unified format: It allows you to quickly map the changes to each file, since the headers tell you the path of every file, and how the comparison is going to be, in this case it compares `/tmp/dotdrop-b3xzkk21` against `~/.i3/config`. It also gives you some context to each change, which the default format doesn't.