### PR TITLE
Fixing custom filters and functions paths

### DIFF
--- a/dotdrop/cfg_yaml.py
+++ b/dotdrop/cfg_yaml.py
@@ -152,6 +152,16 @@ class CfgYaml:
         self.settings[self.key_settings_dotpath] = p
         p = self._norm_path(self.settings[self.key_settings_workdir])
         self.settings[self.key_settings_workdir] = p
+        p = [
+            self._norm_path(p)
+            for p in self.settings[Settings.key_filter_file]
+        ]
+        self.settings[Settings.key_filter_file] = p
+        p = [
+            self._norm_path(p)
+            for p in self.settings[Settings.key_func_file]
+        ]
+        self.settings[Settings.key_func_file] = p
         if self.debug:
             self.log.dbg('settings: {}'.format(self.settings))
 


### PR DESCRIPTION
Your fix in #210 works, but it doesn't resolve filter and function files paths relatively to the current YAML config file.