### PR TITLE
Removing redundant path existence checks in _load_yaml and _import_sub

### DIFF
--- a/dotdrop/cfg_yaml.py
+++ b/dotdrop/cfg_yaml.py
@@ -754,10 +754,7 @@ class CfgYaml:
         """
         if self.debug:
             self.log.dbg('import \"{}\" from \"{}\"'.format(key, path))
-        fnf = self.key_import_fatal_not_found
-        extdict = self._load_yaml(path, fatal_not_found=fnf)
-        if extdict is None and not self.key_import_fatal_not_found:
-            return {}
+        extdict = self._load_yaml(path)
         new = self._get_entry(extdict, key, mandatory=mandatory)
         if patch_func:
             if self.debug:
@@ -967,16 +964,9 @@ class CfgYaml:
         """dump the config dictionary"""
         return self.yaml_dict
 
-    def _load_yaml(self, path, fatal_not_found=True):
+    def _load_yaml(self, path):
         """load a yaml file to a dict"""
         content = {}
-        if not os.path.exists(path):
-            err = 'config path not found: {}'.format(path)
-            if fatal_not_found:
-                raise YamlException(err)
-            else:
-                self.log.warn(err)
-                return None
         try:
             content = self._yaml_load(path)
         except Exception as e:


### PR DESCRIPTION
It's me again. As you noticed, I missed this in my previous pull request.

Shortly, I really don't want to duplicate import-path-handling logic. I overlooked the bit in `_load_yaml` and refactored it to use `_check_path_existence`. But then I went through the code and I realized that paths are already checked for existence, both before calling `_load_yaml` directly, and before calling `_import_sub`. So, there's no reason to check for file existence again. Worst case, if we forget to check, we get an `OSError` when trying to open the path in `_yaml_load`.

I'm not a fan of assuming that the caller checks for existence, but globs create problems. You need to check `:optional` when you expand them, and you don't want to expand globs in `_import_sub` or `_load_yaml`, which should deal with only one file. If you have any other ideas on how to handle the situation more nicely, speak up.