### PR TITLE
Replace `cp` with `rsync` command for import

### DIFF
--- a/dotdrop/dotdrop.py
+++ b/dotdrop/dotdrop.py
@@ -421,7 +421,8 @@ def cmd_importer(o):
                     LOG.err('importing \"{}\" failed!'.format(path))
                     ret = False
                     continue
-            cmd = ['cp', '-R', '-L', '-T', dst, srcf]
+            dst_with_trailing_slash = os.path.join(dst, '')
+            cmd = ['rsync', '-a', '-L', '--delete', dst_with_trailing_slash, srcf]
             if o.dry:
                 LOG.dry('would run: {}'.format(' '.join(cmd)))
             else:


### PR DESCRIPTION
This change allows the import to work on systems without GNU coreutils installed (e.g. macOS, where only BSD cp is available by default).
For BSD specifically, the `-T` flag is missing in `cp`.


The idea to use `rsync` is inspired by [this reply on Stackoverflow](https://stackoverflow.com/a/53349667). Although it is not included in the GNU coreutils, I would say `rsync` is pre-installed on most Linux distributions today, making it a safe choice. What do you think?