### PR TITLE
Replace `cp` with shutils functions for import

### DIFF
--- a/dotdrop/dotdrop.py
+++ b/dotdrop/dotdrop.py
@@ -8,6 +8,8 @@ entry point
 import os
 import sys
 
+import shutil
+
 # local imports
 from dotdrop.options import Options
 from dotdrop.logger import Logger
@@ -421,7 +423,15 @@ def cmd_importer(o):
                     LOG.err('importing \"{}\" failed!'.format(path))
                     ret = False
                     continue
-            cmd = ['cp', '-R', '-L', '-T', dst, srcf]
+            if o.dry:
+                LOG.dry('would copy {} to {}'.format(dst, srcf))
+            else:
+              if os.path.isdir(dst):
+                if os.path.exists(srcf):
+                  shutil.rmtree(srcf)
+                shutil.copytree(dst, srcf)
+              else:
+                shutil.copy2(dst, srcf)
             if o.dry:
                 LOG.dry('would run: {}'.format(' '.join(cmd)))
             else:


### PR DESCRIPTION
This allows the import to work on systems without GNU coreutils
installed (e.g. macOS, where only BSD cp is available by default).
For BSD specifically, the `-T` flag is missing in `cp`.