### PR TITLE
fix PKGBUILD fish completion installation

### DIFF
--- a/packages/arch-dotdrop-git/PKGBUILD
+++ b/packages/arch-dotdrop-git/PKGBUILD
@@ -26,6 +26,6 @@ package() {
   python setup.py install --root="${pkgdir}/" --optimize=1
   install -Dm644 ${srcdir}/${_pkgname}/completion/dotdrop-completion.bash "${pkgdir}/usr/share/bash-completion/completions/${_pkgname}"
   install -Dm644 ${srcdir}/${_pkgname}/completion/_dotdrop-completion.zsh "${pkgdir}/usr/share/zsh/site-functions/_${_pkgname}"
-  install -Dm644 ${srcdir}/${_pkgname}/completion/dotdrop.fish "${pkgdir}/usr/share/fish/completions/"
+  install -Dm644 ${srcdir}/${_pkgname}/completion/dotdrop.fish "${pkgdir}/usr/share/fish/completions/${_pkgname}.fish"
 }
 

--- a/packages/arch-dotdrop/PKGBUILD
+++ b/packages/arch-dotdrop/PKGBUILD
@@ -23,6 +23,6 @@ package() {
   python setup.py install --root="${pkgdir}/" --optimize=1
   install -Dm644 ${srcdir}/${pkgname}/completion/dotdrop-completion.bash "${pkgdir}/usr/share/bash-completion/completions/${pkgname}"
   install -Dm644 ${srcdir}/${pkgname}/completion/_dotdrop-completion.zsh "${pkgdir}/usr/share/zsh/site-functions/_${pkgname}"
-  install -Dm644 ${srcdir}/${_pkgname}/completion/dotdrop.fish "${pkgdir}/usr/share/fish/completions/"
+  install -Dm644 ${srcdir}/${pkgname}/completion/dotdrop.fish "${pkgdir}/usr/share/fish/completions/${pkgname}.fish"
 }
 


### PR DESCRIPTION
- Add the missing destination for the `install` commnad on the fish completion line of both PKGBUILDs.
- On the non-git version, use `$pkgname` over `$_pkgname` since it doas not exist.