### PR TITLE
Improvements to fish completion

### DIFF
--- a/completion/dotdrop.fish
+++ b/completion/dotdrop.fish
@@ -19,6 +19,31 @@ function comp_opt -a "command"
         $argv[2..-1]
 end
 
+function list_profiles
+    dotdrop profiles \
+        --grepable \
+        --no-banner \
+        2> /dev/null
+end
+
+function list_test_keys -a "test_arg"
+    # Return only dotdrop keys in which the src field matches a test(1) criteria
+    #        ^⌣ ^  ← "Slide Time!!"
+    dotdrop files \
+        --grepable \
+        --no-banner \
+        2> /dev/null |
+    while read line
+        # Single use variable because fish's output capture may change soon
+        set -l dst (echo $line | cut -d, -f2 | cut -d: -f2 )
+        if test $test_arg "$dst"
+            echo $line
+        end
+    end |
+    cut -d, -f1
+end
+
+
 # Complete subcommands
 #
 comp_sub -a "install"  -d "Install dotfiles"
@@ -98,7 +123,8 @@ comp_opt "files profiles"\
 #
 comp_opt "install import compare update remove files detail"\
     -x -s p -l profile\
-    -d "Specify the profile to use [default: "(uname -n)"]"
+    -d "Specify the profile to use [default: "(uname -n)"]"\
+    -a "(list_profiles)"
 
 comp_opt "compare update"\
     -x -s i -l ignore\
@@ -129,12 +155,15 @@ comp_opt "update"\
 comp_opt "remove"\
     -F
 
-# TODO: complete keys
-comp_opt "install"\
-    -f
+comp_opt "install detail"\
+    -f\
+    -d "File"\
+    -a "(list_test_keys -f)"
 
-comp_opt "detail"\
-    -f
+comp_opt "install detail"\
+    -f\
+    -d "Directory"\
+    -a "(list_test_keys -d)"
 
 # dotdrop.sh
 #

--- a/completion/dotdrop.fish
+++ b/completion/dotdrop.fish
@@ -46,14 +46,14 @@ end
 
 # Complete subcommands
 #
-comp_sub -a "install"  -d "Install dotfiles"
-comp_sub -a "import"   -d "Import dotfiles into dotdrop"
-comp_sub -a "compare"  -d "Compare your local dotfiles with managed dotfiles"
-comp_sub -a "update"   -d "Update a managed dotfile"
-comp_sub -a "remove"   -d "Remove a managed dotfile"
-comp_sub -a "files"    -d "List managed dotfiles"
-comp_sub -a "detail"   -d "List managed dotfiles details"
-comp_sub -a "profiles" -d "List available profiles"
+comp_sub -k -a "profiles" -d "List available profiles"
+comp_sub -k -a "detail"   -d "List managed dotfiles details"
+comp_sub -k -a "files"    -d "List managed dotfiles"
+comp_sub -k -a "remove"   -d "Remove a managed dotfile"
+comp_sub -k -a "update"   -d "Update a managed dotfile"
+comp_sub -k -a "compare"  -d "Compare your local dotfiles with managed dotfiles"
+comp_sub -k -a "import"   -d "Import dotfiles into dotdrop"
+comp_sub -k -a "install"  -d "Install dotfiles"
 
 # Lone options
 #


### PR DESCRIPTION
# The new Three-in-One Dotdrop fish completions™
## Less tabs, more dots
Subcommands are now ordered by importance and no one would notice it if i did not mention it.
![image](https://user-images.githubusercontent.com/31388299/85361397-2db2cf80-b4f2-11ea-908f-e81bc0b4391e.png)
## Radical profiling
You can now complete `-p --profile`
You are going to use this option, like, once.
![image](https://user-images.githubusercontent.com/31388299/85361497-78cce280-b4f2-11ea-9a69-0a15454f8b42.png)
## That one thing
You can now complete keys for `install` and `detail` (detail does not work for me)
keys are labeled as file or directory, fish auto localizes these.
![image](https://user-images.githubusercontent.com/31388299/85361665-f2fd6700-b4f2-11ea-98a6-d759c2000efc.png)
note the d_mpd there is in fact a file, no error here.

@deadc0de6  thanks for this great piece of software, i **love** it and will surely be using it a lot from now on!