### PR TITLE
Fixing profile variables from included files

### DIFF
--- a/tests-ng/profile-dyninclude.sh
+++ b/tests-ng/profile-dyninclude.sh
@@ -117,14 +117,13 @@ echo "{{@@ maindyn @@}}" >> ${tmps}/dotfiles/abc
 echo "{{@@ subdyn @@}}" >> ${tmps}/dotfiles/abc
 echo "{{@@ subvar @@}}" >> ${tmps}/dotfiles/abc
 echo "end" >> ${tmps}/dotfiles/abc
-cat ${tmps}/dotfiles/abc
+#cat ${tmps}/dotfiles/abc
 
 # install
 cd ${ddpath} | ${bin} install -f -c ${cfg} -p profile_1 --verbose
 
 # check dotfile exists
 [ ! -e ${tmpd}/abc ] && exit 1
-cat ${tmpd}/abc
 grep 'maincontent' ${tmpd}/abc >/dev/null || (echo "variables 1 not resolved" && exit 1)
 grep 'maindyncontent' ${tmpd}/abc >/dev/null || (echo "dynvariables 1 not resolved"  && exit 1)
 grep 'subcontent' ${tmpd}/abc >/dev/null || (echo "variables 2 not resolved" && exit 1)


### PR DESCRIPTION
So, this should fix #246.

What you did was almost right. There were two problems, though: 
- Dynamic variables were executed for each included profile and *the result* of the execution stored as the value in the profile dynamic variables. This creates a problem if the profile is included in more than one other profile, since the second inclusion will try to execute the output of the first run.
- The dynvariables/variables were merged in the global scope only for profiles *directly* included by the selected one. This didn't account for profiles included *indirectly* by directly included profiles.

I solved both the problems by executing dynvariables and merging the variables into globals *after* the loop in `_rec_resolve_profile_include`, only for the selected profile. This way:
- Dynvariables are only executed once, after all the includes for the selected profiles are resolved. This avoids problems with re-executing dynvariables, and also spares CPU cycles by not executing dynvariables not included by any means in the selected profile.
- All the necessary variables, resulting from the recursive include resolution, are merged into global scope, regardles of whether they are included *directly* or *indirectly*.

I also added some logging, removed unused code, and cleaned up the test file a little bit