### PR TITLE
Allowing templating on config variables

### DIFF
--- a/dotdrop/cfg_yaml.py
+++ b/dotdrop/cfg_yaml.py
@@ -142,7 +142,7 @@ class CfgYaml:
 
         # parse the "variables" block
         var = self._parse_blk_variables(self._yaml_dict)
-        self._add_variables(var, template=False)
+        self._add_variables(var, template=True)
 
         # parse the "dynvariables" block
         dvariables = self._parse_blk_dynvariables(self._yaml_dict)
@@ -1100,6 +1100,8 @@ class CfgYaml:
                 val = t.generate_string(val)
                 variables[k] = val
                 t.update_variables(variables)
+        if variables is self.variables:
+            self._redefine_templater()
 
     def _get_profile_included_vars(self):
         """resolve profile included variables/dynvariables"""


### PR DESCRIPTION
This PR fixes a tiny issue in the fix for #250. 

For some reason templating was not allowed when parsing the local `variables` entry in the config file, while it should be, as it's always been allowed. This lead to errors in cases like this (`xdg_config` is an user-defined filter).
```yaml
# config.yaml

dotfiles:
  d_bash:
    src: config/bash
    dst: '{{@@ bdotdir @@}}'

variables:
  bdotdir: '{{@@ xdg_config("bash") @@}}'
```
---
What I did is simply allowing templating when parsing the local `variables` entry, and redefining the templater whenever we resolve variables into the config file's variables (the condition in the `if` checks that the variables are *the exact same object*)