### PR TITLE
Fix missing python-magic dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
 
     keywords='dotfiles jinja2',
     packages=find_packages(exclude=['tests*']),
-    install_requires=['docopt', 'Jinja2', 'ruamel.yaml'],
+    install_requires=['docopt', 'Jinja2', 'ruamel.yaml', 'python-magic'],
 
     extras_require={
         'dev': ['check-manifest'],


### PR DESCRIPTION
The dependency on python-magic is declared in `requirements.txt` but not in `setup.py`. This PR fixes the missing dependency in `setup.py`.

P.S. Thanks a lot for this project! 😃 