### PR TITLE
Make `is_template` respect ignores

### DIFF
--- a/dotdrop/dotdrop.py
+++ b/dotdrop/dotdrop.py
@@ -207,7 +207,13 @@ def _dotfile_install(o, dotfile, tmpdir=None):
         LOG.dbg('installing dotfile: \"{}\"'.format(dotfile.key))
         LOG.dbg(dotfile.prt())
 
-    is_template = dotfile.template and Templategen.is_template(dotfile.src)
+    ignores = list(set(o.install_ignore + dotfile.instignore))
+    ignores = patch_ignores(ignores, dotfile.dst, debug=o.debug)
+
+    is_template = dotfile.template and Templategen.is_template(
+        dotfile.src,
+        ignore=ignores,
+    )
     if hasattr(dotfile, 'link') and dotfile.link == LinkTypes.LINK:
         # link
         r, err = inst.install(t, dotfile.src, dotfile.dst,
@@ -222,7 +228,8 @@ def _dotfile_install(o, dotfile, tmpdir=None):
                               dotfile.link,
                               actionexec=pre_actions_exec,
                               is_template=is_template,
-                              chmod=dotfile.chmod)
+                              chmod=dotfile.chmod,
+                              ignore=ignores)
     else:
         # nolink
         src = dotfile.src

--- a/dotdrop/installer.py
+++ b/dotdrop/installer.py
@@ -149,7 +149,8 @@ class Installer:
             else:
                 r, err = self._link_children(templater, src, dst,
                                              actionexec=actionexec,
-                                             is_template=is_template)
+                                             is_template=is_template,
+                                             ignore=ignore)
 
         if self.debug:
             self.log.dbg('before chmod: {} err:{}'.format(r, err))
@@ -268,7 +269,7 @@ class Installer:
         return r, err
 
     def _link_children(self, templater, src, dst,
-                       actionexec=None, is_template=True):
+                       actionexec=None, is_template=True, ignore=[]):
         """
         install link:link_children
 
@@ -308,6 +309,13 @@ class Installer:
         for i in range(len(children)):
             subsrc = srcs[i]
             subdst = dsts[i]
+
+            if utils.must_ignore([subsrc, subdst], ignore, debug=self.debug):
+                if self.debug:
+                    self.log.dbg(
+                        'ignoring install of {} to {}'.format(src, dst),
+                    )
+                continue
 
             if self.debug:
                 self.log.dbg('symlink child {} to {}'.format(subsrc, subdst))

--- a/dotdrop/templategen.py
+++ b/dotdrop/templategen.py
@@ -218,23 +218,26 @@ class Templategen:
         return data.decode('utf-8', 'replace')
 
     @staticmethod
-    def is_template(path):
+    def is_template(path, ignore=[]):
         """recursively check if any file is a template within path"""
         path = os.path.expanduser(path)
+
+        if utils.must_ignore([path], ignore, debug=False):
+            return False
         if not os.path.exists(path):
             return False
         if os.path.isfile(path):
             # is file
-            return Templategen._is_template(path)
+            return Templategen._is_template(path, ignore=ignore)
         for entry in os.listdir(path):
             fpath = os.path.join(path, entry)
             if not os.path.isfile(fpath):
                 # recursively explore directory
-                if Templategen.is_template(fpath):
+                if Templategen.is_template(fpath, ignore=ignore):
                     return True
             else:
                 # check if file is a template
-                if Templategen._is_template(fpath):
+                if Templategen._is_template(fpath, ignore=ignore):
                     return True
         return False
 
@@ -244,8 +247,10 @@ class Templategen:
         return VAR_START in str(string)
 
     @staticmethod
-    def _is_template(path):
+    def _is_template(path, ignore):
         """test if file pointed by path is a template"""
+        if utils.must_ignore([path], ignore, debug=False):
+            return False
         if not os.path.isfile(path):
             return False
         if os.stat(path).st_size == 0:


### PR DESCRIPTION
A (false positive) "template" that should be ignored
should not make `is_template` become true.

I ran into this when I had the following dotfiles:
```
neovim:
  dst: ~/.config/nvim/
  src: ./vim/
  instignore:
    - '*templated*'
  link: link_children
neovim_templated:
  dst: ~/.config/nvim/templated/
  src: ./vim/templated/

```

I wanted a templated subfolder in my `link_children` neovim config.
The problem is that, even though it is in `instignore`,
the templated folder made the whole `neovim` dotfile a "template".