### PR TITLE
Remove the need for pandoc

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -13,10 +13,8 @@ jobs:
         python-version: 3.8
     - name: Install Tools
       run: |
-        sudo apt update
-        sudo apt -y install python3-pypandoc pandoc
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine pypandoc
+        pip install setuptools wheel twine
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Build and Publish
       env:

--- a/.github/workflows/snapcraft-release.yml
+++ b/.github/workflows/snapcraft-release.yml
@@ -16,8 +16,7 @@ jobs:
       run: |
         export MAGIC=$SNAP/usr/share/file/magic.mgc
         sudo apt update
-        sudo apt -y install git pandoc python3-pip python3-setuptools
-        sudo pip3 install pypandoc
+        sudo apt -y install git python3-pip python3-setuptools
         sudo apt -y install snapd
         sudo snap install snapcraft --classic
         echo "$SNAP_TOKEN" | snapcraft login --with -

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,13 @@
 from setuptools import setup, find_packages
-from codecs import open
 from os import path
 from dotdrop.version import __version__ as VERSION
 
 readme = 'README.md'
 here = path.abspath(path.dirname(__file__))
 
-try:
-    from pypandoc import convert_file
-    read_readme = lambda f: convert_file(f, 'rst')
-except ImportError:
-    print('\n[WARNING] pypandoc not found, could not convert \"{}\"\n'.format(readme))
-    read_readme = lambda f: open(f, 'r').read()
+def read_readme(f):
+    with open(f, encoding="utf-8") as fp:
+        return fp.read()
 
 REQUIRES_PYTHON = '>=3'
 
@@ -21,6 +17,7 @@ setup(
 
     description='Save your dotfiles once, deploy them everywhere',
     long_description=read_readme(readme),
+    long_description_content_type="text/markdown; variant=GFM",
     url='https://github.com/deadc0de6/dotdrop',
     download_url = 'https://github.com/deadc0de6/dotdrop/archive/v'+VERSION+'.tar.gz',
 


### PR DESCRIPTION
For several years now, PyPI has supported Markdown READMEs; all you need to do is set `long_description_content_type` appropriately in your `setup.py`.  This eliminates the need to convert your README from Markdown to reStructuredText with pandoc.