### PR TITLE
dotdrop: respect user-set PYTHONPATH

### DIFF
--- a/dotdrop.sh
+++ b/dotdrop.sh
@@ -36,7 +36,7 @@ hash ${pybin} 2>/dev/null || pybin="python"
 [[ "`${pybin} -V 2>&1`" =~ "Python 3" ]] || { echo "install Python 3" && exit 1; }
 
 # launch dotdrop
-PYTHONPATH=dotdrop ${pybin} -m dotdrop.dotdrop "${args[@]}"
+PYTHONPATH=dotdrop:${PYTHONPATH} ${pybin} -m dotdrop.dotdrop "${args[@]}"
 ret="$?"
 
 # pivot back


### PR DESCRIPTION
This is useful if you're using [PDM](https://pdm.fming.dev/) to manage the repo with Dotdrop installed: PDM also sets PYTHONPATH and the current command simply overrides it which means the PDM path is ignored.