### PR TITLE
add(README.md): add Pacstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Dotdrop is also available on:
 * aur (stable): https://aur.archlinux.org/packages/dotdrop/
 * aur (git version): https://aur.archlinux.org/packages/dotdrop-git/
 * snapcraft: https://snapcraft.io/dotdrop
+* pacstall: https://github.com/pacstall/pacstall-programs/blob/master/packages/dotdrop/dotdrop.pacscript
 
 ## As a submodule
 


### PR DESCRIPTION
Pacstall[](https://pacstall.dev) is an AUR alternative for Debian/Ubuntu. This PR just adds pacscript to list, nothing code related.