### PR TITLE
Fix test_def_link tests by adding missing mock to open() call

### DIFF
--- a/tests/test_yamlcfg.py
+++ b/tests/test_yamlcfg.py
@@ -90,6 +90,7 @@ profiles:
         '''.format(cfgstring)
 
         mock_open.side_effect = [
+                unittest.mock.mock_open(read_data=data).return_value,
                 unittest.mock.mock_open(read_data=data).return_value
                 ]
         mock_exists.return_value = True


### PR DESCRIPTION
I'm reviewing someone's packaging of dotdrop for Debian and spotted this issue.

The mock was setup to only return the mocked data once, but the
function is called twice under cfg_yaml.py, and it breaks at
__yaml_load as there's no mock anymore.
 
I'm also not sure why this wasn't caught by the CI system you're 
using on Github. There doesn't seems to be evidence that this test 
is running (I've tried searching for "link_on_import: link" in the test logs).