### PR TITLE
Bug fix: follow symlinks when templating a source file that is a symlink

### DIFF
--- a/dotdrop/templategen.py
+++ b/dotdrop/templategen.py
@@ -197,8 +197,7 @@ class Templategen:
                 # Canonicalize relative path
                 dst = os.path.join(os.path.dirname(src), dst)
             return self._get_filetype(dst)
-        else:
-            return filetype
+        return filetype
 
     def _handle_file(self, src):
         """generate the file content from template"""

--- a/dotdrop/templategen.py
+++ b/dotdrop/templategen.py
@@ -180,6 +180,7 @@ class Templategen:
         return f'{prepend}{utils.header()}'
 
     def _get_filetype(self, src):
+        """use magic or the file command to get the mime type of a file"""
         try:
             # pylint: disable=C0415
             import magic

--- a/tests-ng/template-link.sh
+++ b/tests-ng/template-link.sh
@@ -81,18 +81,24 @@ cd "${ddpath}" | ${bin} install -f -c "${cfg}" -p p1 -b -V
 
 # checks
 [ ! -e "${tmpd}"/abc ] && echo "[ERROR] dotfile not installed" && exit 1
-diff "${tmpd}"/abc "${expected}" || echo "[ERROR] dotfile not processed by template engine" && exit 1
+diff "${tmpd}"/abc "${expected}" || {
+  echo "[ERROR] dotfile not processed by template engine"
+  exit 1
+}
 
 # test multiple levels of indirection
 ln -s "${tmps}"/dotfiles/ghi "${tmps}"/dotfiles/def
-ln -s "${tmps}"/dotfiles/def "${tmps}"/dotfiles/abc
+ln -s -f "${tmps}"/dotfiles/def "${tmps}"/dotfiles/abc
 
 # install again
 cd "${ddpath}" | ${bin} install -f -c "${cfg}" -p p1 -b -V
 
 # checks again
 [ ! -e "${tmpd}"/abc ] && echo "[ERROR] dotfile not installed" && exit 1
-diff "${tmpd}"/abc "${expected}" || echo "[ERROR] dotfile not processed by template engine" && exit 1
+diff "${tmpd}"/abc "${expected}" || {
+  echo "[ERROR] dotfile not processed by template engine"
+  exit 1
+}
 
 echo "OK"
 exit 0

--- a/tests-ng/template-link.sh
+++ b/tests-ng/template-link.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# author: jtt9340 (https://github.com/jtt9340)
+#
+# test templating a symlink
+# returns 1 in case of error
+#
+
+## start-cookie
+set -e
+cur=$(cd "$(dirname "${0}")" && pwd)
+ddpath="${cur}/../"
+export PYTHONPATH="${ddpath}:${PYTHONPATH}"
+altbin="python3 -m dotdrop.dotdrop"
+if hash coverage 2>/dev/null; then
+  altbin="coverage run -p --source=dotdrop -m dotdrop.dotdrop"
+fi
+bin="${DT_BIN:-${altbin}}"
+# shellcheck source=tests-ng/helpers
+source "${cur}"/helpers
+echo -e "$(tput setaf 6)==> RUNNING $(basename "${BASH_SOURCE[0]}") <==$(tput sgr0)"
+## end-cookie
+
+################################################################
+# this is the test
+################################################################
+
+# the dotfile source
+tmps=$(mktemp -d --suffix='-dotdrop-tests' || mktemp -d)
+mkdir -p "${tmps}"/dotfiles
+echo "dotfiles source (dotpath): ${tmps}"
+# the dotfile destination
+tmpd=$(mktemp -d --suffix='-dotdrop-tests' || mktemp -d)
+echo "dotfiles destination: ${tmpd}"
+# the workdir
+tmpw=$(mktemp -d --suffix='-dotdrop-tests' || mktemp -d)
+export DOTDROP_WORKDIR="${tmpw}"
+echo "workdir: ${tmpw}"
+# expected
+expected=$(mktemp --suffix='-dotdrop-tests' || mktemp)
+echo "expected: ${expected}"
+
+clear_on_exit "${tmps}"
+clear_on_exit "${tmpd}"
+clear_on_exit "${tmpw}"
+clear_on_exit "${expected}"
+
+# create the config file
+cfg="${tmps}/config.yaml"
+
+cat > "${cfg}" << _EOF
+config:
+  backup: true
+  create: true
+  dotpath: dotfiles
+  workdir: ${tmpw}
+dotfiles:
+  f_abc:
+    dst: ${tmpd}/abc
+    src: abc
+profiles:
+  p1:
+    dotfiles:
+    - f_abc
+_EOF
+#cat ${cfg}
+
+# create the expected output
+cat > "${expected}" << _EOF
+p1
+blabla
+_EOF
+
+# create the dotfile
+echo "{{@@ profile @@}}" > "${tmps}"/dotfiles/ghi
+echo "blabla" >> "${tmps}"/dotfiles/ghi
+# dotfile is actually a symlink to a different file
+ln -s "${tmps}"/dotfiles/ghi "${tmps}"/dotfiles/abc
+
+# install
+cd "${ddpath}" | ${bin} install -f -c "${cfg}" -p p1 -b -V
+
+# checks
+[ ! -e "${tmpd}"/abc ] && echo "[ERROR] dotfile not installed" && exit 1
+diff "${tmpd}"/abc "${expected}" || echo "[ERROR] dotfile not processed by template engine" && exit 1
+
+# test multiple levels of indirection
+ln -s "${tmps}"/dotfiles/ghi "${tmps}"/dotfiles/def
+ln -s "${tmps}"/dotfiles/def "${tmps}"/dotfiles/abc
+
+# install again
+cd "${ddpath}" | ${bin} install -f -c "${cfg}" -p p1 -b -V
+
+# checks again
+[ ! -e "${tmpd}"/abc ] && echo "[ERROR] dotfile not installed" && exit 1
+diff "${tmpd}"/abc "${expected}" || echo "[ERROR] dotfile not processed by template engine" && exit 1
+
+echo "OK"
+exit 0


### PR DESCRIPTION
I noticed a bug (or at least a bug to me :wink:) where if the template engine is asked to process a file that is a symlink to a template, the template engine thinks the symlink is a binary file and skips it, when it should probably follow the symlink to see if it is actually a templated text file or a binary file.

My particular use case is that some files in my dotfiles repo are symlinks to other files in the repo, which happen to be templated. When dotdrop installs the dotfiles for that directory containing symlinks, it wasn't templating the files pointed to by the symlinks because it wasn't following the symlink.