### PR TITLE
remove un-managed for #403

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -97,6 +97,7 @@ Some available options:
 * `-a`/`--force-actions`: Force the execution of actions even if the dotfiles are not installed (see [Fake dotfile and actions](config/config-actions.md#fake-dotfile-and-actions) as an alternative)
 * `-f`/`--force`: Do not ask for any confirmation
 * `-W`/`--workdir-clear`: Clear the `workdir` before installing dotfiles (see [the config entry](config/config-config.md) `clear_workdir`)
+* `-R`/`remove-existing`: Applies to directory dotfiles only (`nolink`) and will remove files not managed by dotdrop in the destination directory
 
 To ignore specific patterns during installation, see [the ignore patterns](config/config-file.md#ignore-patterns).
 

--- a/dotdrop/dotdrop.py
+++ b/dotdrop/dotdrop.py
@@ -720,7 +720,8 @@ def _get_install_installer(opts, tmpdir=None):
                      totemp=tmpdir,
                      showdiff=opts.install_showdiff,
                      backup_suffix=opts.install_backup_suffix,
-                     diff_cmd=opts.diff_command)
+                     diff_cmd=opts.diff_command,
+                     remove_existing_in_dir=opts.install_remove_existing)
     return inst
 
 

--- a/dotdrop/installer.py
+++ b/dotdrop/installer.py
@@ -137,13 +137,8 @@ class Installer:
                 ret, err, ins = self._copy_dir(templater, src, dst,
                                                actionexec=actionexec,
                                                noempty=noempty, ignore=ignore,
-                                               is_template=is_template)
-                
-                ret, err = self._copy_dir(templater, src, dst,
-                                          actionexec=actionexec,
-                                          noempty=noempty, ignore=ignore,
-                                          is_template=is_template,
-                                          chmod=chmod)
+                                               is_template=is_template,
+                                               chmod=chmod)
                 if self.remove_existing_in_dir and ins:
                     self._remove_existing_in_dir(dst, ins)
             else:

--- a/dotdrop/installer.py
+++ b/dotdrop/installer.py
@@ -612,7 +612,7 @@ class Installer:
         - False, None       : ignored
         - False, 'aborted'    : user aborted
 
-        third arg returned is the list managed dotfiles
+        third arg returned is the list of managed dotfiles
         in the destination or an empty list if anything
         fails
         """

--- a/dotdrop/installer.py
+++ b/dotdrop/installer.py
@@ -672,6 +672,9 @@ class Installer:
             if self.dry:
                 self.log.dry(f'would remove {path}')
                 continue
+            if self.safe:
+                if not self.log.ask(f'remove unmanaged \"{path}\"'):
+                    return
             self.log.dbg(f'removing not managed: {path}')
             removepath(path, logger=self.log)
 

--- a/dotdrop/options.py
+++ b/dotdrop/options.py
@@ -58,19 +58,19 @@ USAGE = f"""
 {BANNER}
 
 Usage:
-  dotdrop install   [-VbtfndDaW] [-c <path>] [-p <profile>]
-                                 [-w <nb>] [<key>...]
-  dotdrop import    [-Vbdfm]     [-c <path>] [-p <profile>] [-i <pattern>...]
-                                 [--transr=<key>] [--transw=<key>]
-                                 [-l <link>] [-s <path>] <path>...
-  dotdrop compare   [-LVbz]      [-c <path>] [-p <profile>]
-                                 [-w <nb>] [-C <file>...] [-i <pattern>...]
-  dotdrop update    [-VbfdkPz]   [-c <path>] [-p <profile>]
-                                 [-w <nb>] [-i <pattern>...] [<path>...]
-  dotdrop remove    [-Vbfdk]     [-c <path>] [-p <profile>] [<path>...]
-  dotdrop files     [-VbTG]      [-c <path>] [-p <profile>]
-  dotdrop detail    [-Vb]        [-c <path>] [-p <profile>] [<key>...]
-  dotdrop profiles  [-VbG]       [-c <path>]
+  dotdrop install   [-VbtfndDaWR] [-c <path>] [-p <profile>]
+                                  [-w <nb>] [<key>...]
+  dotdrop import    [-Vbdfm]      [-c <path>] [-p <profile>] [-i <pattern>...]
+                                  [--transr=<key>] [--transw=<key>]
+                                  [-l <link>] [-s <path>] <path>...
+  dotdrop compare   [-LVbz]       [-c <path>] [-p <profile>]
+                                  [-w <nb>] [-C <file>...] [-i <pattern>...]
+  dotdrop update    [-VbfdkPz]    [-c <path>] [-p <profile>]
+                                  [-w <nb>] [-i <pattern>...] [<path>...]
+  dotdrop remove    [-Vbfdk]      [-c <path>] [-p <profile>] [<path>...]
+  dotdrop files     [-VbTG]       [-c <path>] [-p <profile>]
+  dotdrop detail    [-Vb]         [-c <path>] [-p <profile>] [<key>...]
+  dotdrop profiles  [-VbG]        [-c <path>]
   dotdrop --help
   dotdrop --version
 
@@ -91,6 +91,7 @@ Options:
   -n --nodiff             Do not diff when installing.
   -p --profile=<profile>  Specify the profile to use [default: {PROFILE}].
   -P --show-patch         Provide a one-liner to manually patch template.
+  -R --remove-existing    Remove existing file on install directory.
   -s --as=<path>          Import as a different path from actual path.
   --transr=<key>          Associate trans_read key on import.
   --transw=<key>          Apply trans_write key on import.
@@ -297,6 +298,7 @@ class Options(AttrMonitor):
         self.install_force_chmod = self.force_chmod
         self.install_clear_workdir = self.args['--workdir-clear'] or \
             self.clear_workdir
+        self.install_remove_existing = self.args['--remove-existing']
 
     def _apply_args_compare(self):
         """compare specifics"""

--- a/scripts/check-syntax.sh
+++ b/scripts/check-syntax.sh
@@ -50,7 +50,7 @@ echo "---------------------------------"
 echo "checking for bash strict mode"
 find tests-ng -iname '*.sh' | while read -r script; do
   #grep 'set +e' "${script}" 2>&1 >/dev/null && echo "set +e found in ${script}" && exit 1
-  grep 'set \-euo errtrace pipefail' "${script}" || (echo "set -euo errtrace pipefail not set in ${script}" && exit 1 )
+  grep 'set -euo errtrace pipefail' "${script}" >/dev/null 2>&1 || (echo "set -euo errtrace pipefail not set in ${script}" && exit 1 )
 done
 
 # PEP8 tests

--- a/tests-ng/install-and-remove.sh
+++ b/tests-ng/install-and-remove.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# author: deadc0de6 (https://github.com/deadc0de6)
+# Copyright (c) 2023, deadc0de6
+#
+# test install and remove existing file in fs
+# returns 1 in case of error
+#
+
+## start-cookie
+set -euo errtrace pipefail
+cur=$(cd "$(dirname "${0}")" && pwd)
+ddpath="${cur}/../"
+PPATH="{PYTHONPATH:-}"
+export PYTHONPATH="${ddpath}:${PPATH}"
+altbin="python3 -m dotdrop.dotdrop"
+if hash coverage 2>/dev/null; then
+  mkdir -p coverages/
+  altbin="coverage run -p --data-file coverages/coverage --source=dotdrop -m dotdrop.dotdrop"
+fi
+bin="${DT_BIN:-${altbin}}"
+# shellcheck source=tests-ng/helpers
+source "${cur}"/helpers
+echo -e "$(tput setaf 6)==> RUNNING $(basename "${BASH_SOURCE[0]}") <==$(tput sgr0)"
+## end-cookie
+
+################################################################
+# this is the test
+################################################################
+
+# dotdrop directory
+basedir=$(mktemp -d --suffix='-dotdrop-tests' || mktemp -d)
+mkdir -p "${basedir}"/dotfiles
+echo "[+] dotdrop dir: ${basedir}"
+echo "[+] dotpath dir: ${basedir}/dotfiles"
+tmpd=$(mktemp -d --suffix='-dotdrop-tests' || mktemp -d)
+
+clear_on_exit "${basedir}"
+clear_on_exit "${tmpd}"
+
+# create the config file
+cfg="${basedir}/config.yaml"
+cat > "${cfg}" << _EOF
+config:
+  backup: true
+  create: true
+  dotpath: dotfiles
+dotfiles:
+  d_dir:
+    src: dir
+    dst: ${tmpd}/dir
+profiles:
+  p1:
+    dotfiles:
+    - d_dir
+_EOF
+
+# create the file in dotpath
+mkdir -p "${basedir}"/dotfiles/dir
+echo "content" > "${basedir}"/dotfiles/dir/file
+
+# create the file in fs
+mkdir -p "${tmpd}"/dir
+echo "content" > "${tmpd}"/dir/existing
+
+echo "[+] install"
+cd "${ddpath}" | ${bin} install -c "${cfg}" -f -p p1 --verbose
+[ "$?" != "0" ] && exit 1
+
+[ ! -e "${tmpd}"/dir/file ] && echo "d_dir file not installed" && exit 1
+[ ! -e "${tmpd}"/dir/existing ] && echo "existing removed" && exit 1
+
+echo "[+] install with remove"
+cd "${ddpath}" | ${bin} install --remove-existing -c "${cfg}" -f -p p1 --verbose
+[ "$?" != "0" ] && exit 1
+
+[ ! -e "${tmpd}"/dir/file ] && echo "d_dir file not installed" && exit 1
+[ -e "${tmpd}"/dir/existing ] && echo "existing not removed" && exit 1
+
+echo "OK"
+exit 0

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -144,6 +144,7 @@ def _fake_args():
     args['--workdir-clear'] = False
     args['--transw'] = ''
     args['--transr'] = ''
+    args['--remove-existing'] = False
     # cmds
     args['profiles'] = False
     args['files'] = False


### PR DESCRIPTION
this adds an option to dotdrop `install`: `--remove-existing`.

this will, on `install`, remove any files not managed by dotdrop. It only applies to directory dotfiles with a link type of `nolink`.