### PR TITLE
Ignore virtual envs in pylint checks in check-syntax.sh

### DIFF
--- a/scripts/check-syntax.sh
+++ b/scripts/check-syntax.sh
@@ -111,7 +111,7 @@ done
 # check other python scripts
 echo "-----------------------------------------"
 echo "checking other python scripts with pylint"
-find . -name "*.py" -not -path "./dotdrop/*" | while read -r script; do
+find . -name "*.py" -not -path "./dotdrop/*" -not -regex "\./\.?v?env/.*" | while read -r script; do
   echo "checking ${script}"
   pylint -sn \
     --disable=R0914 \


### PR DESCRIPTION
It is common to place the virtual environment into the repository folder, and this is already supported recognized in the `.gitignore`. Also ignore these folders in `tests.sh`.