### PR TITLE
precedence doc for #443

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,10 @@ levels in not accurate anymore.
 * Profile `(dyn)variables` > profile's included `(dyn)variables`
 * Imported `variables`/`dynvariables` > `(dyn)variables`
 
+When `import_configs` importing config's elements except the `(dyn)variables`
+will take precedence in case of name clash
+(see <https://github.com/deadc0de6/dotdrop/issues/443>).
+
 ## Variable resolution
 
 How variables are resolved (through Jinja2's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,7 +213,7 @@ for a match with the ignore patterns.
 
 Dotdrop is tested with the use of the [tests.sh](/tests.sh) script.
 
-* Test for PEP8 compliance with `pylint`, `pycodestyle` and `pyflakes` (see [check-syntax.sh](/scripts/test-syntax.sh))
+* Test for PEP8 compliance with `pylint`, `pycodestyle` and `pyflakes` (see [check-syntax.sh](/scripts/check-syntax.sh))
 * Test the documentation and links (see [check-doc.sh](/scripts/check-doc.sh))
 * Run the unittests in [tests directory](/tests) with pytest (see [check-unittest.sh](/scripts/check-unittests.sh))
 * Run the blackbox bash script tests in [tests-ng directory](/tests-ng) (see [check-tests-ng.sh](/scripts/check-tests-ng.sh))

--- a/docs/config/config-config.md
+++ b/docs/config/config-config.md
@@ -187,6 +187,10 @@ import_configs:
 - other-config.yaml:optional
 ```
 
+In case of a name clash (same name in importing and imported configs),
+the importing config will take precedence except for the `variables` and `dynvariables`
+(see [variable](config-file.md#variables) and [CONTRIBUTING doc](/CONTRIBUTING.md)).
+
 ## default_actions entry
 
 Dotdrop allows to execute an action for any dotfile installation. These actions work as any other action (`pre` or `post`).


### PR DESCRIPTION
improve documentation on precedence in case of name clash when using `import_configs`

see #443 