### PR TITLE
Switch from docopt to docopt-ng

### DIFF
--- a/packages/arch-dotdrop-git/PKGBUILD
+++ b/packages/arch-dotdrop-git/PKGBUILD
@@ -3,13 +3,13 @@
 _pkgname=dotdrop
 pkgname="${_pkgname}-git"
 pkgver=1.3.7.r13.g18b156e
-pkgrel=8
+pkgrel=9
 pkgdesc="Save your dotfiles once, deploy them everywhere "
 arch=('any')
 url="https://github.com/deadc0de6/dotdrop"
 license=('GPL')
 groups=()
-depends=('python' 'python-setuptools' 'python-jinja' 'python-docopt' 'python-ruamel-yaml' 'python-magic' 'python-requests' 'python-packaging' 'python-tomli-w' 'python-distro')
+depends=('python' 'python-setuptools' 'python-jinja' 'python-docopt-ng' 'python-ruamel-yaml' 'python-magic' 'python-requests' 'python-packaging' 'python-tomli-w' 'python-distro')
 makedepends=('git')
 provides=(dotdrop)
 conflicts=(dotdrop)

--- a/packages/arch-dotdrop/PKGBUILD
+++ b/packages/arch-dotdrop/PKGBUILD
@@ -2,13 +2,13 @@
 
 pkgname=dotdrop
 pkgver=1.5.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Save your dotfiles once, deploy them everywhere "
 arch=('any')
 url="https://github.com/deadc0de6/dotdrop"
 license=('GPL')
 groups=()
-depends=('python' 'python-setuptools' 'python-jinja' 'python-docopt' 'python-ruamel-yaml' 'python-magic' 'python-requests' 'python-packaging' 'python-tomli-w' 'python-distro')
+depends=('python' 'python-setuptools' 'python-jinja' 'python-docopt-ng' 'python-ruamel-yaml' 'python-magic' 'python-requests' 'python-packaging' 'python-tomli-w' 'python-distro')
 makedepends=('git')
 source=("git+https://github.com/deadc0de6/dotdrop.git#tag=v${pkgver}")
 md5sums=('SKIP')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2; python_version > '3.5'
-docopt; python_version > '3.5'
+docopt-ng; python_version > '3.5'
 ruamel.yaml; python_version > '3.5'
 python-magic; python_version > '3.5'
 packaging; python_version > '3.5'

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     keywords='dotfiles jinja2',
     packages=find_packages(exclude=['tests*']),
     install_requires=[
-        'docopt', 'Jinja2', 'ruamel.yaml',
+        'docopt-ng', 'Jinja2', 'ruamel.yaml',
         'python-magic', 'packaging', 'requests',
         'tomli; python_version < "3.11"',
         'tomli_w', 'distro'],


### PR DESCRIPTION
Running dotdrop under recent releases of Python — 3.12 and 3.13 — [outputs syntax warnings] from the docopt module.

[outputs syntax warnings]:
  https://docs.python.org/3/whatsnew/3.12.html#other-language-changes

<details>

<summary>Output with syntax warnings on Python 3.12 and 3.13</summary>

Command to run `dotdrop` with Python 3.12:

    rm -rf ~/.cache/uv \
    && ~/.local/bin/uv tool run --python=python3.12 dotdrop install --profile=default

Output:

```
   Built docopt==0.6.2
Installed 15 packages in 7ms
/home/maxwell-k/.cache/uv/archive-v0/IhmhuswofFs7ywBBC0kJs/lib64/python3.12/site-packages/docopt.py:165: SyntaxWarning: invalid escape sequence '\S'
  name = re.findall('(<\S*?>)', source)[0]
/home/maxwell-k/.cache/uv/archive-v0/IhmhuswofFs7ywBBC0kJs/lib64/python3.12/site-packages/docopt.py:166: SyntaxWarning: invalid escape sequence '\['
  value = re.findall('\[default: (.*)\]', source, flags=re.I)
/home/maxwell-k/.cache/uv/archive-v0/IhmhuswofFs7ywBBC0kJs/lib64/python3.12/site-packages/docopt.py:207: SyntaxWarning: invalid escape sequence '\['
  matched = re.findall('\[default: (.*)\]', description, flags=re.I)
/home/maxwell-k/.cache/uv/archive-v0/IhmhuswofFs7ywBBC0kJs/lib64/python3.12/site-packages/docopt.py:456: SyntaxWarning: invalid escape sequence '\S'
  split = re.split('\n *(<\S+?>|-\S+?)', doc)[1:]
     _       _      _
  __| | ___ | |_ __| |_ __ ___  _ __
 / _` |/ _ \| __/ _` | '__/ _ \| '_ |
 \__,_|\___/ \__\__,_|_|  \___/| .__/  v1.14.2
                               |_|

0 dotfile(s) installed.
```

The output is similar using `python3.13`.

</details>

[docopt] hasn't had a [release to PyPI] in 10 years. [No wheels] are published to PyPI. `docopt` is used throughout the [dotdrop] code base. Advice online suggests adopting [docopt-ng] instead.

[docopt]: https://github.com/docopt/docopt
[no wheels]: https://github.com/docopt/docopt/issues/502
[release to PyPI]: https://pypi.org/project/docopt/#history
[docopt-ng]: https://github.com/jazzband/docopt-ng
[dotdrop]: https://github.com/deadc0de6/dotdrop