### PR TITLE
upload sdist to pypi

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -22,5 +22,5 @@ jobs:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       run: |
-        python3 -m build --wheel --no-isolation
+        python3 -m build --no-isolation
         twine upload dist/*


### PR DESCRIPTION
This is needed for anyone building from source, such as downstream distributors like Homebrew. See https://packaging.python.org/en/latest/discussions/package-formats/#package-formats

> When publishing a package on PyPI (or elsewhere), you should always upload both an sdist and one or more wheel.